### PR TITLE
Port WebGPU Merkle tree from Lita-Plonky2 wasm branch + security fixes

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -86,6 +86,14 @@ jobs:
           CARGO_INCREMENTAL: 1
           RUST_BACKTRACE: 1
 
+      - name: Check in plonky2 subdirectory with gpu_merkle (WebGPU)
+        run: cargo check --manifest-path plonky2/Cargo.toml --target wasm32-unknown-unknown --no-default-features --features gpu_merkle
+        env:
+          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
+          RUST_LOG: 1
+          CARGO_INCREMENTAL: 1
+          RUST_BACKTRACE: 1
+
       - name: Check in starky subdirectory for wasm targets
         run: cargo check --manifest-path starky/Cargo.toml --target wasm32-unknown-unknown --no-default-features
         env:

--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -16,7 +16,7 @@ default = []
 # default = ["gate_testing", "parallel", "rand_chacha", "std", "timing"]
 gate_testing = []
 parallel = ["hashbrown/rayon", "plonky2_maybe_rayon/parallel"]
-std = ["anyhow/std", "rand/std", "itertools/use_std", "dep:futures"]
+std = ["anyhow/std", "rand/std", "itertools/use_std", "dep:futures", "dep:pollster"]
 timing = ["std", "dep:web-time"]
 merkle_debug_print = ["dep:console_log"]
 gpu_merkle = [
@@ -51,6 +51,7 @@ unroll = { workspace = true }
 web-time = { version = "1.0.0", optional = true }
 futures = { version = "0.3", optional = true, default-features = false, features = ["executor", "std", "async-await"] }
 futures-channel = "0.3"
+pollster = { version = "0.3", optional = true }
 
 # Local dependencies
 plonky2_field = { version = "1.0.0", path = "../field", default-features = false }

--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -26,7 +26,6 @@ gpu_merkle = [
     "dep:wasm-bindgen",
     "dep:wasm-bindgen-futures",
     "dep:web-sys",
-    "dep:js-sys",
     "dep:console_error_panic_hook",
     "dep:console_log",
     "dep:once_cell",
@@ -71,7 +70,7 @@ gloo-timers = { version = "*", features = ["futures"] }
 bytemuck = { version = "1.18", features = ["derive"], optional = true }
 console_error_panic_hook = { version = "0.1", optional = true }
 getrandom = { version = "0.2", default-features = false, features = ["js"] }
-js-sys = { version = "0.3", optional = true }
+js-sys = { version = "0.3", optional = false }
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 web-sys = { version = "0.3", features = ["console", "Performance"], optional = true }

--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -16,8 +16,24 @@ default = []
 # default = ["gate_testing", "parallel", "rand_chacha", "std", "timing"]
 gate_testing = []
 parallel = ["hashbrown/rayon", "plonky2_maybe_rayon/parallel"]
-std = ["anyhow/std", "rand/std", "itertools/use_std"]
+std = ["anyhow/std", "rand/std", "itertools/use_std", "dep:futures"]
 timing = ["std", "dep:web-time"]
+merkle_debug_print = ["dep:console_log"]
+gpu_merkle = [
+    "std",
+    "dep:wgpu",
+    "dep:bytemuck",
+    "dep:wasm-bindgen",
+    "dep:wasm-bindgen-futures",
+    "dep:web-sys",
+    "dep:js-sys",
+    "dep:console_error_panic_hook",
+    "dep:console_log",
+    "dep:once_cell",
+]
+gpu_merkle_verbose_time_logging = ["gpu_merkle"]
+gpu_merkle_logging = ["gpu_merkle", "gpu_merkle_verbose_time_logging"]
+wasm_test_exports = []
 
 [dependencies]
 ahash = { workspace = true }
@@ -33,6 +49,8 @@ serde = { workspace = true, features = ["rc"] }
 static_assertions = { workspace = true }
 unroll = { workspace = true }
 web-time = { version = "1.0.0", optional = true }
+futures = { version = "0.3", optional = true, default-features = false, features = ["executor", "std", "async-await"] }
+futures-channel = "0.3"
 
 # Local dependencies
 plonky2_field = { version = "1.0.0", path = "../field", default-features = false }
@@ -40,9 +58,25 @@ plonky2_maybe_rayon = { version = "1.0.0", path = "../maybe_rayon", default-feat
 plonky2_util = { version = "1.0.0", path = "../util", default-features = false }
 serde_with = "3.15.0"
 
+# multi producer, multi consumer async channels that work on native and wasm
+flume = "0.11"
+
+# For panic error messages in WASM code
+console_error_panic_hook = "0.1.7"
+
+gloo-timers = { version = "*", features = ["futures"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+bytemuck = { version = "1.18", features = ["derive"], optional = true }
+console_error_panic_hook = { version = "0.1", optional = true }
 getrandom = { version = "0.2", default-features = false, features = ["js"] }
+js-sys = { version = "0.3", optional = true }
+wasm-bindgen = { version = "0.2", optional = true }
+wasm-bindgen-futures = { version = "0.4", optional = true }
+web-sys = { version = "0.3", features = ["console", "Performance"], optional = true }
+wgpu = { version = "26", default-features = false, features = ["webgpu", "wgsl"], optional = true }
+once_cell = { version = "1.20", default-features = false, features = ["std"], optional = true }
+console_log = { version = "1.0.0", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", default-features = false }
@@ -92,3 +126,7 @@ rustdoc-args = ["--html-in-header", ".cargo/katex-header.html"]
 
 [lints]
 workspace = true
+
+# For WASM Merkle tree test case
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/plonky2/shaders/buffer_canonical_to_montgomery.wgsl
+++ b/plonky2/shaders/buffer_canonical_to_montgomery.wgsl
@@ -1,0 +1,265 @@
+requires unrestricted_pointer_parameters;
+
+@group(0) @binding(0) var<storage, read_write> buf: array<BigInt>;
+@group(0) @binding(1) var<storage, read> num: i32;
+
+var<private> carry_flag: u32 = 0u;
+const M: BigInt = BigInt(array(u32(1), u32(4294967295)));
+const MontyOne: BigInt = BigInt(array(u32(4294967295), u32(0)));
+const PP1D2: BigInt = BigInt(array(u32(2147483649), u32(2147483647)));
+const M0NInv: u32 = 4294967295;
+const R2modP: BigInt = BigInt(array(u32(1), u32(4294967294)));
+const WORKGROUP_SIZE: i32 = 64;
+
+struct BigInt {
+  limbs: array<u32, 2>,
+};
+
+@compute @workgroup_size(WORKGROUP_SIZE)
+fn bufferToMontgomery(@builtin(global_invocation_id) global_id: vec3<u32>, @builtin(num_workgroups) num_workgroups: vec3<u32>) {
+  /* Assumes the input is a flat buffer of field elements in *canonical representation*.
+The kernel transforms every field element into Montgomery representation. */;
+  let grid_width: u32 = (num_workgroups.x * 64u);
+  let tid: i32 = ((i32(global_id.y) * i32(grid_width)) + i32(global_id.x));
+  if ((num <= tid)) {
+    return ;
+  };
+  toMont_smut((&buf[tid]));
+}
+
+fn toMont_smut(r: ptr<storage, BigInt, read_write>) {
+  /* Transform a bigint ``a`` from it's natural representation (mod N)
+to a the Montgomery n-residue representation
+
+Montgomery-Multiplication - based
+
+with W = M.len
+and R = (2^WordBitWidth)^W
+
+Does "a * R (mod M)" */;
+  (*r) = mtymul_FIPS___k9bOh0PcBpU1aIxwHtw19b0w((*r), R2modP, M, false);
+}
+
+fn mtymul_FIPS___k9bOh0PcBpU1aIxwHtw19b0w(a: BigInt, b: BigInt, M: BigInt, lazyReduce: bool) -> BigInt {
+  /* Montgomery Multiplication using Finely Integrated Product Scanning (FIPS).
+This implementation can be used for fields that do not have any spare bits.
+
+This maps
+- [0, 2p) -> [0, 2p) with lazyReduce
+- [0, 2p) -> [0, p) without
+
+lazyReduce skips the final substraction step. */;
+;
+  var z: BigInt = BigInt(array<u32, 2>());
+  const L: i32 = 2;
+  var t: u32 = 0u;
+  var u: u32 = 0u;
+  var v: u32 = 0u;
+
+  { // unrolledIter_i0
+
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), a.limbs[0], b.limbs[0]);
+  z.limbs[0] = (v * 4294967295u);
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), z.limbs[0], M.limbs[0]);
+  v = u;
+  u = t;
+  t = 0u;
+  } // unrolledIter_i0
+
+
+  { // unrolledIter_i1
+
+  { // unrolledIter_j0
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), a.limbs[0], b.limbs[1]);
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), z.limbs[0], M.limbs[1]);
+  } // unrolledIter_j0
+
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), a.limbs[1], b.limbs[0]);
+  z.limbs[1] = (v * 4294967295u);
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), z.limbs[1], M.limbs[0]);
+  v = u;
+  u = t;
+  t = 0u;
+  } // unrolledIter_i1
+
+
+  { // unrolledIter_i2
+
+  { // unrolledIter_j1
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), a.limbs[1], b.limbs[1]);
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), z.limbs[1], M.limbs[1]);
+  } // unrolledIter_j1
+
+  z.limbs[0] = v;
+  v = u;
+  u = t;
+  t = 0u;
+  } // unrolledIter_i2
+
+
+  { // unrolledIter_i3
+
+  z.limbs[1] = v;
+  v = u;
+  u = t;
+  t = 0u;
+  } // unrolledIter_i3
+
+  let cond: bool = (!(v == 0u) || !less(z, M));
+  csub_no_mod_lmut_l_l((&z), M, cond);
+  return z;
+}
+
+fn mulAcc_lmut_lmut_lmut_l_l(t: ptr<function, u32>, u: ptr<function, u32>, v: ptr<function, u32>, a: u32, b: u32) {
+  /* (t, u, v) <- (t, u, v) + a * b */;
+  (*v) = mulloadd_co(a, b, (*v));
+  (*u) = mulhiadd_cio(a, b, (*u));
+  (*t) = add_ci((*t), 0u);
+}
+
+fn mulloadd_co(a: u32, b: u32, c: u32) -> u32 {
+  /* Multiply-add low with carry out */;
+  let product: u32 = mul_lo(a, b);
+  return add_co(product, c);
+}
+
+fn mul_lo(a: u32, b: u32) -> u32 {
+  /* Returns the lower 32 bit of the uint32 multiplication
+Native WGSL multiplication automatically wraps to 32 bits */;
+  return (a * b);
+}
+
+fn add_co(a: u32, b: u32) -> u32 {
+  let result: u32 = (a + b);
+  carry_flag = select(0u, 1u, (result < a));
+  return result;
+}
+
+fn mulhiadd_cio(a: u32, b: u32, c: u32) -> u32 {
+  /* Multiply-add high with carry in and carry out */;
+  let hi_product: u32 = mul_hi(a, b);
+  return add_cio(hi_product, c);
+}
+
+fn mul_hi(a: u32, b: u32) -> u32 {
+  /* Returns the upper 32 bit of the uint32 multiplication
+Decompose into 16-bit chunks to avoid overflow */;
+  let a_lo: u32 = (a & 65535u);
+  let a_hi: u32 = (a >> 16);
+  let b_lo: u32 = (b & 65535u);
+  let b_hi: u32 = (b >> 16);
+  let p0: u32 = (a_lo * b_lo);
+  let p1: u32 = (a_lo * b_hi);
+  let p2: u32 = (a_hi * b_lo);
+  let p3: u32 = (a_hi * b_hi);
+  let middle: u32 = (((p0 >> 16) + (p1 & 65535u)) + (p2 & 65535u));
+  let carry: u32 = (middle >> 16);
+  return (((p3 + (p1 >> 16)) + (p2 >> 16)) + carry);
+}
+
+fn add_cio(a: u32, b: u32) -> u32 {
+  let temp: u32 = (a + b);
+  let result: u32 = (temp + carry_flag);
+  carry_flag = select(0u, 1u, ((temp < a) || (result < temp)));
+  return result;
+}
+
+fn add_ci(a: u32, b: u32) -> u32 {
+  let temp: u32 = (a + b);
+  let result: u32 = (temp + carry_flag);
+  return result;
+}
+
+fn less(a: BigInt, b: BigInt) -> bool {
+  /* Returns true if a < b for two big ints in *canonical*
+representation.
+
+NOTE: The inputs are compared *as is*. That means if they are
+in Montgomery representation the result will not reflect the
+ordering relation of their associated canonical values!
+Call `toCanonical` on field elements in Montgomery order before
+comparing them.
+
+Comparison is constant-time */;
+  var borrow: u32;
+  sub_bo(a.limbs[0], b.limbs[0]);
+
+  { // unrolledIter_i1
+  sub_bio(a.limbs[1], b.limbs[1]);
+  } // unrolledIter_i1
+
+  borrow = sub_bi(0u, 0u);
+  return bool(borrow);
+}
+
+fn sub_bo(a: u32, b: u32) -> u32 {
+  let result: u32 = (a - b);
+  carry_flag = select(0u, 1u, (a < b));
+  return result;
+}
+
+fn sub_bio(a: u32, b: u32) -> u32 {
+  let temp: u32 = (a - b);
+  let result: u32 = (temp - carry_flag);
+  carry_flag = select(0u, 1u, ((a < b) || (temp < carry_flag)));
+  return result;
+}
+
+fn sub_bi(a: u32, b: u32) -> u32 {
+  let temp: u32 = (a - b);
+  let result: u32 = (temp - carry_flag);
+  return result;
+}
+
+fn csub_no_mod_lmut_l_l(r: ptr<function, BigInt>, a: BigInt, condition: bool) {
+  /* Conditionally subtract `a` from `r` in place *without* modular
+reduction.
+
+Note: This is constant-time */;
+  var t: BigInt = BigInt(array<u32, 2>());
+  sub_no_mod___EEn9a4b5Jsqd9aZULV449aWXA_lmut_l_l((&t), (*r), a);
+  ccopy___0Yi84Y9bRtBTBkxwWVoQtDQ_lmut_l_l(r, t, condition);
+}
+
+fn sub_no_mod___EEn9a4b5Jsqd9aZULV449aWXA_lmut_l_l(r: ptr<function, BigInt>, a: BigInt, b: BigInt) {
+  /* Subtraction of two finite field elements stored in `a` and `b`
+*without* modular reduction.
+The result is stored in `r`. */;
+  (*r) = sub_no_mod(a, b);
+}
+
+fn sub_no_mod(a: BigInt, b: BigInt) -> BigInt {
+  /* Generate an optimized substraction kernel
+with parameters `a, b, modulus: Limbs -> Limbs`
+I.e. this does _not_ perform modular reduction. */;
+  var t: BigInt = BigInt(array<u32, 2>());
+  t.limbs[0] = sub_bo(a.limbs[0], b.limbs[0]);
+
+  { // unrolledIter_i1
+  t.limbs[1] = sub_bio(a.limbs[1], b.limbs[1]);
+  } // unrolledIter_i1
+
+  return t;
+}
+
+fn ccopy___0Yi84Y9bRtBTBkxwWVoQtDQ_lmut_l_l(a: ptr<function, BigInt>, b: BigInt, condition: bool) {
+  /* Conditional copy.
+If condition is true: b is copied into a
+If condition is false: a is left unmodified
+
+Note: This is constant-time */;
+  /* XXX: add support for `IfExpr`! Requires though. */;
+  var cond: i32;
+  if (condition) {
+    cond = 1;
+  } else {
+    cond = -1;
+  };
+  for(var i: i32 = 0; i < 2; i++) {
+    (*a).limbs[i] = slct(b.limbs[i], (*a).limbs[i], cond);
+  };
+}
+
+fn slct(a: u32, b: u32, pred: i32) -> u32 {
+  return select(b, a, (0 <= pred));
+}

--- a/plonky2/shaders/buffer_montgomery_to_canonical.wgsl
+++ b/plonky2/shaders/buffer_montgomery_to_canonical.wgsl
@@ -1,0 +1,234 @@
+requires unrestricted_pointer_parameters;
+
+@group(0) @binding(0) var<storage, read_write> buf: array<BigInt>;
+@group(0) @binding(1) var<storage, read> num: i32;
+
+var<private> carry_flag: u32 = 0u;
+const M: BigInt = BigInt(array(u32(1), u32(4294967295)));
+const MontyOne: BigInt = BigInt(array(u32(4294967295), u32(0)));
+const PP1D2: BigInt = BigInt(array(u32(2147483649), u32(2147483647)));
+const M0NInv: u32 = 4294967295;
+const R2modP: BigInt = BigInt(array(u32(1), u32(4294967294)));
+const WORKGROUP_SIZE: i32 = 64;
+
+struct BigInt {
+  limbs: array<u32, 2>,
+};
+
+@compute @workgroup_size(WORKGROUP_SIZE)
+fn bufferToCanonical(@builtin(global_invocation_id) global_id: vec3<u32>, @builtin(num_workgroups) num_workgroups: vec3<u32>) {
+  /* Assumes the input is a flat buffer of field elements in *Montgomery representation*.
+The kernel transforms every field element into canonical representation. */;
+  let grid_width: u32 = (num_workgroups.x * 64u);
+  let tid: i32 = ((i32(global_id.y) * i32(grid_width)) + i32(global_id.x));
+  if ((num <= tid)) {
+    return ;
+  };
+  toCanonical_smut((&buf[tid]));
+}
+
+fn toCanonical_smut(r: ptr<storage, BigInt, read_write>) {
+  fromMont_CIOS_smut_l_l_l(r, (*r), M, 4294967295);
+}
+
+fn fromMont_CIOS_smut_l_l_l(r: ptr<storage, BigInt, read_write>, a: BigInt, M: BigInt, m0ninv: u32) {
+  /* Convert from Montgomery form to canonical BigInt form */;
+  var t: BigInt = a;
+
+  { // unrolledIter_i0
+  let m: u32 = (t.limbs[0] * m0ninv);
+  var C: u32;
+  var lo: u32;
+  muladd1_gpu_lmut_lmut_l_l_l((&C), (&lo), m, M.limbs[0], t.limbs[0]);
+
+  { // unrolledIter_j1
+  muladd2_gpu_lmut_lmut_l_l_l_l((&C), (&t.limbs[0]), m, M.limbs[1], C, t.limbs[1]);
+  } // unrolledIter_j1
+
+  t.limbs[1] = C;
+  } // unrolledIter_i0
+
+
+  { // unrolledIter_i1
+  let m: u32 = (t.limbs[0] * m0ninv);
+  var C: u32;
+  var lo: u32;
+  muladd1_gpu_lmut_lmut_l_l_l((&C), (&lo), m, M.limbs[0], t.limbs[0]);
+
+  { // unrolledIter_j1
+  muladd2_gpu_lmut_lmut_l_l_l_l((&C), (&t.limbs[0]), m, M.limbs[1], C, t.limbs[1]);
+  } // unrolledIter_j1
+
+  t.limbs[1] = C;
+  } // unrolledIter_i1
+
+  csub_no_mod_lmut_l_l((&t), M, !less(t, M));
+  (*r) = t;
+}
+
+fn muladd1_gpu_lmut_lmut_l_l_l(hi: ptr<function, u32>, lo: ptr<function, u32>, a: u32, b: u32, c: u32) {
+  /* Extended precision multiplication + addition
+(hi, lo) <- a*b + c
+
+Note: 0xFFFFFFFF_FFFFFFFF² -> (hi: 0xFFFFFFFFFFFFFFFE, lo: 0x0000000000000001)
+      so adding any c cannot overflow
+
+Note: `_gpu` prefix to not confuse Nim compiler with `precompute/muladd1` */;
+  (*lo) = mulloadd_co(a, b, c);
+  (*hi) = mulhiadd_ci(a, b, 0u);
+}
+
+fn mulloadd_co(a: u32, b: u32, c: u32) -> u32 {
+  /* Multiply-add low with carry out */;
+  let product: u32 = mul_lo(a, b);
+  return add_co(product, c);
+}
+
+fn mul_lo(a: u32, b: u32) -> u32 {
+  /* Returns the lower 32 bit of the uint32 multiplication
+Native WGSL multiplication automatically wraps to 32 bits */;
+  return (a * b);
+}
+
+fn add_co(a: u32, b: u32) -> u32 {
+  let result: u32 = (a + b);
+  carry_flag = select(0u, 1u, (result < a));
+  return result;
+}
+
+fn mulhiadd_ci(a: u32, b: u32, c: u32) -> u32 {
+  /* Multiply-add high with carry in */;
+  let hi_product: u32 = mul_hi(a, b);
+  return add_ci(hi_product, c);
+}
+
+fn mul_hi(a: u32, b: u32) -> u32 {
+  /* Returns the upper 32 bit of the uint32 multiplication
+Decompose into 16-bit chunks to avoid overflow */;
+  let a_lo: u32 = (a & 65535u);
+  let a_hi: u32 = (a >> 16);
+  let b_lo: u32 = (b & 65535u);
+  let b_hi: u32 = (b >> 16);
+  let p0: u32 = (a_lo * b_lo);
+  let p1: u32 = (a_lo * b_hi);
+  let p2: u32 = (a_hi * b_lo);
+  let p3: u32 = (a_hi * b_hi);
+  let middle: u32 = (((p0 >> 16) + (p1 & 65535u)) + (p2 & 65535u));
+  let carry: u32 = (middle >> 16);
+  return (((p3 + (p1 >> 16)) + (p2 >> 16)) + carry);
+}
+
+fn add_ci(a: u32, b: u32) -> u32 {
+  let temp: u32 = (a + b);
+  let result: u32 = (temp + carry_flag);
+  return result;
+}
+
+fn muladd2_gpu_lmut_lmut_l_l_l_l(hi: ptr<function, u32>, lo: ptr<function, u32>, a: u32, b: u32, c1: u32, c2: u32) {
+  /* Extended precision multiplication + addition + addition
+(hi, lo) <- a*b + c1 + c2
+
+Note: 0xFFFFFFFF_FFFFFFFF² -> (hi: 0xFFFFFFFFFFFFFFFE, lo: 0x0000000000000001)
+      so adding 0xFFFFFFFFFFFFFFFF leads to (hi: 0xFFFFFFFFFFFFFFFF, lo: 0x0000000000000000)
+      and we have enough space to add again 0xFFFFFFFFFFFFFFFF without overflowing
+
+Note: `_gpu` prefix to not confuse Nim compiler with `precompute/muladd2` */;
+  (*lo) = mulloadd_co(a, b, c1);
+  (*hi) = mulhiadd_ci(a, b, 0u);
+  (*lo) = add_co((*lo), c2);
+  (*hi) = add_ci((*hi), 0u);
+}
+
+fn csub_no_mod_lmut_l_l(r: ptr<function, BigInt>, a: BigInt, condition: bool) {
+  /* Conditionally subtract `a` from `r` in place *without* modular
+reduction.
+
+Note: This is constant-time */;
+  var t: BigInt = BigInt(array<u32, 2>());
+  sub_no_mod___YjG9b0jr1jXlGGbLNhPCgRQ_lmut_l_l((&t), (*r), a);
+  ccopy___gIWNSC2oOW4mX8SJJVXvNg_lmut_l_l(r, t, condition);
+}
+
+fn sub_no_mod___YjG9b0jr1jXlGGbLNhPCgRQ_lmut_l_l(r: ptr<function, BigInt>, a: BigInt, b: BigInt) {
+  /* Subtraction of two finite field elements stored in `a` and `b`
+*without* modular reduction.
+The result is stored in `r`. */;
+  (*r) = sub_no_mod(a, b);
+}
+
+fn sub_no_mod(a: BigInt, b: BigInt) -> BigInt {
+  /* Generate an optimized substraction kernel
+with parameters `a, b, modulus: Limbs -> Limbs`
+I.e. this does _not_ perform modular reduction. */;
+  var t: BigInt = BigInt(array<u32, 2>());
+  t.limbs[0] = sub_bo(a.limbs[0], b.limbs[0]);
+
+  { // unrolledIter_i1
+  t.limbs[1] = sub_bio(a.limbs[1], b.limbs[1]);
+  } // unrolledIter_i1
+
+  return t;
+}
+
+fn sub_bo(a: u32, b: u32) -> u32 {
+  let result: u32 = (a - b);
+  carry_flag = select(0u, 1u, (a < b));
+  return result;
+}
+
+fn sub_bio(a: u32, b: u32) -> u32 {
+  let temp: u32 = (a - b);
+  let result: u32 = (temp - carry_flag);
+  carry_flag = select(0u, 1u, ((a < b) || (temp < carry_flag)));
+  return result;
+}
+
+fn ccopy___gIWNSC2oOW4mX8SJJVXvNg_lmut_l_l(a: ptr<function, BigInt>, b: BigInt, condition: bool) {
+  /* Conditional copy.
+If condition is true: b is copied into a
+If condition is false: a is left unmodified
+
+Note: This is constant-time */;
+  /* XXX: add support for `IfExpr`! Requires though. */;
+  var cond: i32;
+  if (condition) {
+    cond = 1;
+  } else {
+    cond = -1;
+  };
+  for(var i: i32 = 0; i < 2; i++) {
+    (*a).limbs[i] = slct(b.limbs[i], (*a).limbs[i], cond);
+  };
+}
+
+fn slct(a: u32, b: u32, pred: i32) -> u32 {
+  return select(b, a, (0 <= pred));
+}
+
+fn less(a: BigInt, b: BigInt) -> bool {
+  /* Returns true if a < b for two big ints in *canonical*
+representation.
+
+NOTE: The inputs are compared *as is*. That means if they are
+in Montgomery representation the result will not reflect the
+ordering relation of their associated canonical values!
+Call `toCanonical` on field elements in Montgomery order before
+comparing them.
+
+Comparison is constant-time */;
+  var borrow: u32;
+  sub_bo(a.limbs[0], b.limbs[0]);
+
+  { // unrolledIter_i1
+  sub_bio(a.limbs[1], b.limbs[1]);
+  } // unrolledIter_i1
+
+  borrow = sub_bi(0u, 0u);
+  return bool(borrow);
+}
+
+fn sub_bi(a: u32, b: u32) -> u32 {
+  let temp: u32 = (a - b);
+  let result: u32 = (temp - carry_flag);
+  return result;
+}

--- a/plonky2/shaders/merkle_tree.wgsl
+++ b/plonky2/shaders/merkle_tree.wgsl
@@ -1,0 +1,639 @@
+@group(0) @binding(0) var<storage, read_write> input: array<P1HashDigest>;
+@group(0) @binding(1) var<storage, read_write> nodes: array<P1HashDigest>;
+@group(0) @binding(2) var<storage, read_write> cap: array<P1HashDigest>;
+@group(0) @binding(3) var<storage, read> args: MerkleTreeKernelArgs;
+@group(0) @binding(4) var<storage, read> mdsCirc: array<BigInt, 12>;
+@group(0) @binding(5) var<storage, read> mdsDiag: array<BigInt, 12>;
+@group(0) @binding(6) var<storage, read> rc: array<BigInt, 360>;
+
+const WORKGROUP_SIZE: u32 = 64u;
+const WORKGROUP_SIZE_Y: u32 = 1u;
+var<private> carry_flag: u32 = 0u;
+const M: BigInt = BigInt(array(u32(1), u32(4294967295)));
+const MontyOne: BigInt = BigInt(array(u32(4294967295), u32(0)));
+const PP1D2: BigInt = BigInt(array(u32(2147483649), u32(2147483647)));
+const M0NInv: u32 = 4294967295;
+const R2modP: BigInt = BigInt(array(u32(1), u32(4294967294)));
+
+struct BigInt {
+  limbs: array<u32, 2>,
+};
+struct P1HashDigest {
+  elems: array<BigInt, 4>,
+};
+struct MerkleTreeKernelArgs {
+  capLen: u32,
+  layer: u32,
+  srcLayerSize: u32,
+  dstLayerSize: u32,
+  srcOffset: u32,
+  dstOffset: u32,
+  writeToCap: i32,
+};
+
+@compute @workgroup_size(WORKGROUP_SIZE, WORKGROUP_SIZE_Y)
+fn processMerkleTreeLayerWithCap(@builtin(local_invocation_id)  local_id : vec3<u32>,      // ≈ CUDA threadIdx
+@builtin(workgroup_id)         workgroup_id: vec3<u32>,   // ≈ CUDA blockIdx
+@builtin(num_workgroups)       num_workgroups: vec3<u32>, // ≈ CUDA gridDim
+@builtin(global_invocation_id) global_id: vec3<u32>,      // = workgroup_id * workgroup_size + local_id
+) {
+  /* Process a single layer of the Merkle tree with cap support using
+the layer-based storage layout shared with the proof generator.
+
+TODO: In theory there's no reason to differentiate between the cap and
+the nodes. The cap is just the last N nodes. We can precompute the indices
+at which the cap is located and handle copying back the correct nodes
+as part of the Nim (CPU) routine that copies the results back. */;
+  let grid_width: u32 = (num_workgroups.x * 64u);
+  let tid: u32 = ((u32(global_id.y) * u32(grid_width)) + u32(global_id.x));
+  if ((args.dstLayerSize <= tid)) {
+    return ;
+  };
+  let leftIdx: u32 = (tid * 2u);
+  let rightIdx: u32 = (leftIdx + 1u);
+  var state: array<BigInt, 12>;
+
+  { // unrolledIter_i0
+  setZero_lmut((&state[0]));
+  } // unrolledIter_i0
+
+
+  { // unrolledIter_i1
+  setZero_lmut((&state[1]));
+  } // unrolledIter_i1
+
+
+  { // unrolledIter_i2
+  setZero_lmut((&state[2]));
+  } // unrolledIter_i2
+
+
+  { // unrolledIter_i3
+  setZero_lmut((&state[3]));
+  } // unrolledIter_i3
+
+
+  { // unrolledIter_i4
+  setZero_lmut((&state[4]));
+  } // unrolledIter_i4
+
+
+  { // unrolledIter_i5
+  setZero_lmut((&state[5]));
+  } // unrolledIter_i5
+
+
+  { // unrolledIter_i6
+  setZero_lmut((&state[6]));
+  } // unrolledIter_i6
+
+
+  { // unrolledIter_i7
+  setZero_lmut((&state[7]));
+  } // unrolledIter_i7
+
+
+  { // unrolledIter_i8
+  setZero_lmut((&state[8]));
+  } // unrolledIter_i8
+
+
+  { // unrolledIter_i9
+  setZero_lmut((&state[9]));
+  } // unrolledIter_i9
+
+
+  { // unrolledIter_i10
+  setZero_lmut((&state[10]));
+  } // unrolledIter_i10
+
+
+  { // unrolledIter_i11
+  setZero_lmut((&state[11]));
+  } // unrolledIter_i11
+
+  if ((args.layer == 0u)) {
+    writeData_lmut_l_smut_l((&state), 0, (&input), leftIdx);
+    if ((rightIdx < args.srcLayerSize)) {
+      writeData_lmut_l_smut_l((&state), 4, (&input), rightIdx);
+    };
+  } else {
+    writeData_lmut_l_smut_l((&state), 0, (&nodes), (args.srcOffset + leftIdx));
+    if ((rightIdx < args.srcLayerSize)) {
+      writeData_lmut_l_smut_l((&state), 4, (&nodes), (args.srcOffset + rightIdx));
+    };
+  };
+  poseidonPermuteMutImpl_lmut((&state));
+  if ((args.writeToCap == 1)) {
+    if ((tid < args.capLen)) {
+
+      { // unrolledIter_i0
+      cap[tid].elems[0] = getCanonical(state[0]);
+      } // unrolledIter_i0
+
+
+      { // unrolledIter_i1
+      cap[tid].elems[1] = getCanonical(state[1]);
+      } // unrolledIter_i1
+
+
+      { // unrolledIter_i2
+      cap[tid].elems[2] = getCanonical(state[2]);
+      } // unrolledIter_i2
+
+
+      { // unrolledIter_i3
+      cap[tid].elems[3] = getCanonical(state[3]);
+      } // unrolledIter_i3
+
+    };
+  } else {
+
+    { // unrolledIter_i0
+    nodes[(args.dstOffset + tid)].elems[0] = state[0];
+    } // unrolledIter_i0
+
+
+    { // unrolledIter_i1
+    nodes[(args.dstOffset + tid)].elems[1] = state[1];
+    } // unrolledIter_i1
+
+
+    { // unrolledIter_i2
+    nodes[(args.dstOffset + tid)].elems[2] = state[2];
+    } // unrolledIter_i2
+
+
+    { // unrolledIter_i3
+    nodes[(args.dstOffset + tid)].elems[3] = state[3];
+    } // unrolledIter_i3
+
+  };
+}
+
+fn setZero_lmut(a: ptr<function, BigInt>) {
+  /* Sets all limbs of the field element to zero in place */;
+  for(var i: u32 = 0u; i < 2; i++) {
+    (*a).limbs[i] = 0u;
+  };
+}
+
+fn writeData_lmut_l_smut_l(dst: ptr<function, array<BigInt, 12>>, dstOffset: u32, data: ptr<storage, array<P1HashDigest>, read_write>, srcOffset: u32) {
+  /* Writes all elements from `data` at `srcOffset` to `dstOffset` in `state`. */;
+
+  { // unrolledIter_i0
+  (*dst)[(dstOffset + u32(0))] = (*data)[srcOffset].elems[0];
+  } // unrolledIter_i0
+
+
+  { // unrolledIter_i1
+  (*dst)[(dstOffset + u32(1))] = (*data)[srcOffset].elems[1];
+  } // unrolledIter_i1
+
+
+  { // unrolledIter_i2
+  (*dst)[(dstOffset + u32(2))] = (*data)[srcOffset].elems[2];
+  } // unrolledIter_i2
+
+
+  { // unrolledIter_i3
+  (*dst)[(dstOffset + u32(3))] = (*data)[srcOffset].elems[3];
+  } // unrolledIter_i3
+
+}
+
+fn poseidonPermuteMutImpl_lmut(state: ptr<function, array<BigInt, 12>>) {
+  /* Main Poseidon permutation - inlined for performance */;
+  var roundCtr: u32 = 0;
+  fullRounds_lmut_lmut(state, (&roundCtr));
+  partialRoundsNaive_lmut_lmut(state, (&roundCtr));
+  fullRounds_lmut_lmut(state, (&roundCtr));
+}
+
+fn fullRounds_lmut_lmut(state: ptr<function, array<BigInt, 12>>, round_ctr: ptr<function, u32>) {
+  for(var i: u32 = 0; i < 4u; i++) {
+    constantLayer_lmut_lmut(state, round_ctr);
+    sboxLayer_lmut(state);
+    mdsLayer_lmut(state);
+    (*round_ctr) = ((*round_ctr) + 1u);
+  };
+}
+
+fn constantLayer_lmut_lmut(state: ptr<function, array<BigInt, 12>>, round_ctr: ptr<function, u32>) {
+  for(var i: u32 = 0; i < 12; i++) {
+    let round_constant: BigInt = rc[(i + (12u * (*round_ctr)))];
+    /* XXX: add canonical u64?
+-> Need to construct Montgomery? We just need to turn round constants into
+Montgomery before! */;
+    add_lmut_l_l((&(*state)[i]), (*state)[i], round_constant);
+  };
+}
+
+fn add_lmut_l_l(r: ptr<function, BigInt>, a: BigInt, b: BigInt) {
+  /* Addition of two finite field elements stored in `a` and `b`.
+The result is stored in `r`. */;
+  (*r) = modadd(a, b, M);
+}
+
+fn modadd(a: BigInt, b: BigInt, M: BigInt) -> BigInt {
+  /* Generate an optimized modular addition kernel
+with parameters `a, b, modulus: Limbs -> Limbs` */;
+  var t: BigInt = BigInt(array<u32, 2>());
+  t.limbs[0] = add_co(a.limbs[0], b.limbs[0]);
+
+  { // unrolledIter_i1
+  t.limbs[1] = add_cio(a.limbs[1], b.limbs[1]);
+  } // unrolledIter_i1
+
+  let overflowedLimbs: u32 = add_ci(0u, 0u);
+  t = finalSubMayOverflow(t, M, overflowedLimbs);
+  return t;
+}
+
+fn add_co(a: u32, b: u32) -> u32 {
+  let result: u32 = (a + b);
+  carry_flag = select(0u, 1u, (result < a));
+  return result;
+}
+
+fn add_cio(a: u32, b: u32) -> u32 {
+  let temp: u32 = (a + b);
+  let result: u32 = (temp + carry_flag);
+  carry_flag = select(0u, 1u, ((temp < a) || (result < temp)));
+  return result;
+}
+
+fn add_ci(a: u32, b: u32) -> u32 {
+  let temp: u32 = (a + b);
+  let result: u32 = (temp + carry_flag);
+  return result;
+}
+
+fn finalSubMayOverflow(a: BigInt, M: BigInt, overflowedLimbs: u32) -> BigInt {
+  /* If a >= Modulus: r <- a-M
+else:            r <- a
+
+This is constant-time straightline code.
+Due to warp divergence, the overhead of doing comparison with shortcutting might not be worth it on GPU.
+
+To be used when the final substraction can
+also overflow the limbs (a 2^256 order of magnitude modulus stored in n words of total max size 2^256) */;
+  var scratch: BigInt = BigInt(array<u32, 2>());
+  scratch.limbs[0] = sub_bo(a.limbs[0], M.limbs[0]);
+
+  { // unrolledIter_i1
+  scratch.limbs[1] = sub_bio(a.limbs[1], M.limbs[1]);
+  } // unrolledIter_i1
+
+  let underflowedModulus: u32 = sub_bi(overflowedLimbs, 0u);
+  var r: BigInt = BigInt(array<u32, 2>());
+
+  { // unrolledIter_i0
+  r.limbs[0] = slct(scratch.limbs[0], a.limbs[0], bitcast<i32>(underflowedModulus));
+  } // unrolledIter_i0
+
+
+  { // unrolledIter_i1
+  r.limbs[1] = slct(scratch.limbs[1], a.limbs[1], bitcast<i32>(underflowedModulus));
+  } // unrolledIter_i1
+
+  return r;
+}
+
+fn sub_bo(a: u32, b: u32) -> u32 {
+  let result: u32 = (a - b);
+  carry_flag = select(0u, 1u, (a < b));
+  return result;
+}
+
+fn sub_bio(a: u32, b: u32) -> u32 {
+  let temp: u32 = (a - b);
+  let result: u32 = (temp - carry_flag);
+  carry_flag = select(0u, 1u, ((a < b) || (temp < carry_flag)));
+  return result;
+}
+
+fn sub_bi(a: u32, b: u32) -> u32 {
+  let temp: u32 = (a - b);
+  let result: u32 = (temp - carry_flag);
+  return result;
+}
+
+fn slct(a: u32, b: u32, pred: i32) -> u32 {
+  return select(b, a, (0 <= pred));
+}
+
+fn sboxLayer_lmut(state: ptr<function, array<BigInt, 12>>) {
+  for(var i: u32 = 0; i < 12; i++) {
+    (*state)[i] = sboxMonomial((*state)[i]);
+  };
+}
+
+fn sboxMonomial(x: BigInt) -> BigInt {
+  var x2: BigInt;
+  var x3: BigInt;
+  var x4: BigInt;
+  mul_lmut_l_l((&x2), x, x);
+  mul_lmut_l_l((&x4), x2, x2);
+  mul_lmut_l_l((&x3), x, x2);
+  mul_lmut_l_l((&x2), x3, x4);
+  return x2;
+}
+
+fn mul_lmut_l_l(r: ptr<function, BigInt>, a: BigInt, b: BigInt) {
+  /* Multiplication of two finite field elements stored in `a` and `b`.
+The result is stored in `r`. */;
+  (*r) = mtymul_FIPS___f4FuSyv5EILd5KB2IIWyig(a, b, M, false);
+}
+
+fn mtymul_FIPS___f4FuSyv5EILd5KB2IIWyig(a: BigInt, b: BigInt, M: BigInt, lazyReduce: bool) -> BigInt {
+  /* Montgomery Multiplication using Finely Integrated Product Scanning (FIPS).
+This implementation can be used for fields that do not have any spare bits.
+
+This maps
+- [0, 2p) -> [0, 2p) with lazyReduce
+- [0, 2p) -> [0, p) without
+
+lazyReduce skips the final substraction step. */;
+;
+  var z: BigInt = BigInt(array<u32, 2>());
+  const L: i32 = 2;
+  var t: u32 = 0u;
+  var u: u32 = 0u;
+  var v: u32 = 0u;
+
+  { // unrolledIter_i0
+
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), a.limbs[0], b.limbs[0]);
+  z.limbs[0] = (v * 4294967295u);
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), z.limbs[0], M.limbs[0]);
+  v = u;
+  u = t;
+  t = 0u;
+  } // unrolledIter_i0
+
+
+  { // unrolledIter_i1
+
+  { // unrolledIter_j0
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), a.limbs[0], b.limbs[1]);
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), z.limbs[0], M.limbs[1]);
+  } // unrolledIter_j0
+
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), a.limbs[1], b.limbs[0]);
+  z.limbs[1] = (v * 4294967295u);
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), z.limbs[1], M.limbs[0]);
+  v = u;
+  u = t;
+  t = 0u;
+  } // unrolledIter_i1
+
+
+  { // unrolledIter_i2
+
+  { // unrolledIter_j1
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), a.limbs[1], b.limbs[1]);
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), z.limbs[1], M.limbs[1]);
+  } // unrolledIter_j1
+
+  z.limbs[0] = v;
+  v = u;
+  u = t;
+  t = 0u;
+  } // unrolledIter_i2
+
+
+  { // unrolledIter_i3
+
+  z.limbs[1] = v;
+  v = u;
+  u = t;
+  t = 0u;
+  } // unrolledIter_i3
+
+  let cond: bool = (!(v == 0u) || !less(z, M));
+  csub_no_mod_lmut_l_l((&z), M, cond);
+  return z;
+}
+
+fn mulAcc_lmut_lmut_lmut_l_l(t: ptr<function, u32>, u: ptr<function, u32>, v: ptr<function, u32>, a: u32, b: u32) {
+  /* (t, u, v) <- (t, u, v) + a * b */;
+  (*v) = mulloadd_co(a, b, (*v));
+  (*u) = mulhiadd_cio(a, b, (*u));
+  (*t) = add_ci((*t), 0u);
+}
+
+fn mulloadd_co(a: u32, b: u32, c: u32) -> u32 {
+  /* Multiply-add low with carry out */;
+  let product: u32 = mul_lo(a, b);
+  return add_co(product, c);
+}
+
+fn mul_lo(a: u32, b: u32) -> u32 {
+  /* Returns the lower 32 bit of the uint32 multiplication
+Native WGSL multiplication automatically wraps to 32 bits */;
+  return (a * b);
+}
+
+fn mulhiadd_cio(a: u32, b: u32, c: u32) -> u32 {
+  /* Multiply-add high with carry in and carry out */;
+  let hi_product: u32 = mul_hi(a, b);
+  return add_cio(hi_product, c);
+}
+
+fn mul_hi(a: u32, b: u32) -> u32 {
+  /* Returns the upper 32 bit of the uint32 multiplication
+Decompose into 16-bit chunks to avoid overflow */;
+  let a_lo: u32 = (a & 65535u);
+  let a_hi: u32 = (a >> 16);
+  let b_lo: u32 = (b & 65535u);
+  let b_hi: u32 = (b >> 16);
+  let p0: u32 = (a_lo * b_lo);
+  let p1: u32 = (a_lo * b_hi);
+  let p2: u32 = (a_hi * b_lo);
+  let p3: u32 = (a_hi * b_hi);
+  let middle: u32 = (((p0 >> 16) + (p1 & 65535u)) + (p2 & 65535u));
+  let carry: u32 = (middle >> 16);
+  return (((p3 + (p1 >> 16)) + (p2 >> 16)) + carry);
+}
+
+fn less(a: BigInt, b: BigInt) -> bool {
+  /* Returns true if a < b for two big ints in *canonical*
+representation.
+
+NOTE: The inputs are compared *as is*. That means if they are
+in Montgomery representation the result will not reflect the
+ordering relation of their associated canonical values!
+Call `toCanonical` on field elements in Montgomery order before
+comparing them.
+
+Comparison is constant-time */;
+  var borrow: u32;
+  sub_bo(a.limbs[0], b.limbs[0]);
+
+  { // unrolledIter_i1
+  sub_bio(a.limbs[1], b.limbs[1]);
+  } // unrolledIter_i1
+
+  borrow = sub_bi(0u, 0u);
+  return bool(borrow);
+}
+
+fn csub_no_mod_lmut_l_l(r: ptr<function, BigInt>, a: BigInt, condition: bool) {
+  /* Conditionally subtract `a` from `r` in place *without* modular
+reduction.
+
+Note: This is constant-time */;
+  var t: BigInt = BigInt(array<u32, 2>());
+  sub_no_mod___d9cpFFTTlwIJez0po9bQ0J4g_lmut_l_l((&t), (*r), a);
+  ccopy___HjzYt6G86OUE1KbkDccyqg_lmut_l_l(r, t, condition);
+}
+
+fn sub_no_mod___d9cpFFTTlwIJez0po9bQ0J4g_lmut_l_l(r: ptr<function, BigInt>, a: BigInt, b: BigInt) {
+  /* Subtraction of two finite field elements stored in `a` and `b`
+*without* modular reduction.
+The result is stored in `r`. */;
+  (*r) = sub_no_mod(a, b);
+}
+
+fn sub_no_mod(a: BigInt, b: BigInt) -> BigInt {
+  /* Generate an optimized substraction kernel
+with parameters `a, b, modulus: Limbs -> Limbs`
+I.e. this does _not_ perform modular reduction. */;
+  var t: BigInt = BigInt(array<u32, 2>());
+  t.limbs[0] = sub_bo(a.limbs[0], b.limbs[0]);
+
+  { // unrolledIter_i1
+  t.limbs[1] = sub_bio(a.limbs[1], b.limbs[1]);
+  } // unrolledIter_i1
+
+  return t;
+}
+
+fn ccopy___HjzYt6G86OUE1KbkDccyqg_lmut_l_l(a: ptr<function, BigInt>, b: BigInt, condition: bool) {
+  /* Conditional copy.
+If condition is true: b is copied into a
+If condition is false: a is left unmodified
+
+Note: This is constant-time */;
+  /* XXX: add support for `IfExpr`! Requires though. */;
+  var cond: i32;
+  if (condition) {
+    cond = 1;
+  } else {
+    cond = -1;
+  };
+  for(var i: u32 = 0u; i < 2; i++) {
+    (*a).limbs[i] = slct(b.limbs[i], (*a).limbs[i], cond);
+  };
+}
+
+fn mdsLayer_lmut(state: ptr<function, array<BigInt, 12>>) {
+  /* XXX: Return copy? Better mutate in place?
+XXX: We could consider an implementation closer to the regular implementation
+Plonky2 uses for generic fields. But that requires us to implement a `u128` type
+with _at least_ multiplication. */;
+  var tmp: array<BigInt, 12>;
+  /* XXX: avoid this copy? */;
+  tmp = (*state);
+  for(var r: u32 = 0; r < 12; r++) {
+    /* XXX: pass by reference! */;
+    (*state)[r] = mdsRowShfNaive(r, tmp);
+  };
+}
+
+fn mdsRowShfNaive(r: u32, v: array<BigInt, 12>) -> BigInt {
+  var res: BigInt = BigInt(array<u32, 2>());
+  var val: BigInt;
+  for(var i: u32 = 0; i < 12; i++) {
+    mul_lmut_l_l((&val), v[((i + r) % 12u)], mdsCirc[i]);
+    add_lmut_l_l((&res), res, val);
+  };
+  mul_lmut_l_l((&val), v[r], mdsDiag[r]);
+  add_lmut_l_l((&res), res, val);
+  return res;
+}
+
+fn partialRoundsNaive_lmut_lmut(state: ptr<function, array<BigInt, 12>>, round_ctr: ptr<function, u32>) {
+  for(var i: u32 = 0; i < 22u; i++) {
+    constantLayer_lmut_lmut(state, round_ctr);
+    (*state)[0] = sboxMonomial((*state)[0]);
+    mdsLayer_lmut(state);
+    (*round_ctr) = ((*round_ctr) + 1u);
+  };
+}
+
+fn getCanonical(b: BigInt) -> BigInt {
+  var canon: BigInt;
+  fromMont_CIOS_lmut_l_l_l((&canon), b, M, 4294967295);
+  return canon;
+}
+
+fn fromMont_CIOS_lmut_l_l_l(r: ptr<function, BigInt>, a: BigInt, M: BigInt, m0ninv: u32) {
+  /* Convert from Montgomery form to canonical BigInt form */;
+  var t: BigInt = a;
+
+  { // unrolledIter_i0
+  let m: u32 = (t.limbs[0] * m0ninv);
+  var C: u32;
+  var lo: u32;
+  muladd1_gpu_lmut_lmut_l_l_l((&C), (&lo), m, M.limbs[0], t.limbs[0]);
+
+  { // unrolledIter_j1
+  muladd2_gpu_lmut_lmut_l_l_l_l((&C), (&t.limbs[0]), m, M.limbs[1], C, t.limbs[1]);
+  } // unrolledIter_j1
+
+  t.limbs[1] = C;
+  } // unrolledIter_i0
+
+
+  { // unrolledIter_i1
+  let m: u32 = (t.limbs[0] * m0ninv);
+  var C: u32;
+  var lo: u32;
+  muladd1_gpu_lmut_lmut_l_l_l((&C), (&lo), m, M.limbs[0], t.limbs[0]);
+
+  { // unrolledIter_j1
+  muladd2_gpu_lmut_lmut_l_l_l_l((&C), (&t.limbs[0]), m, M.limbs[1], C, t.limbs[1]);
+  } // unrolledIter_j1
+
+  t.limbs[1] = C;
+  } // unrolledIter_i1
+
+  csub_no_mod_lmut_l_l((&t), M, !less(t, M));
+  (*r) = t;
+}
+
+fn muladd1_gpu_lmut_lmut_l_l_l(hi: ptr<function, u32>, lo: ptr<function, u32>, a: u32, b: u32, c: u32) {
+  /* Extended precision multiplication + addition
+(hi, lo) <- a*b + c
+
+Note: 0xFFFFFFFF_FFFFFFFF² -> (hi: 0xFFFFFFFFFFFFFFFE, lo: 0x0000000000000001)
+      so adding any c cannot overflow
+
+Note: `_gpu` prefix to not confuse Nim compiler with `precompute/muladd1` */;
+  (*lo) = mulloadd_co(a, b, c);
+  (*hi) = mulhiadd_ci(a, b, 0u);
+}
+
+fn mulhiadd_ci(a: u32, b: u32, c: u32) -> u32 {
+  /* Multiply-add high with carry in */;
+  let hi_product: u32 = mul_hi(a, b);
+  return add_ci(hi_product, c);
+}
+
+fn muladd2_gpu_lmut_lmut_l_l_l_l(hi: ptr<function, u32>, lo: ptr<function, u32>, a: u32, b: u32, c1: u32, c2: u32) {
+  /* Extended precision multiplication + addition + addition
+(hi, lo) <- a*b + c1 + c2
+
+Note: 0xFFFFFFFF_FFFFFFFF² -> (hi: 0xFFFFFFFFFFFFFFFE, lo: 0x0000000000000001)
+      so adding 0xFFFFFFFFFFFFFFFF leads to (hi: 0xFFFFFFFFFFFFFFFF, lo: 0x0000000000000000)
+      and we have enough space to add again 0xFFFFFFFFFFFFFFFF without overflowing
+
+Note: `_gpu` prefix to not confuse Nim compiler with `precompute/muladd2` */;
+  (*lo) = mulloadd_co(a, b, c1);
+  (*hi) = mulhiadd_ci(a, b, 0u);
+  (*lo) = add_co((*lo), c2);
+  (*hi) = add_ci((*hi), 0u);
+}
+

--- a/plonky2/shaders/poseidon1_hash.wgsl
+++ b/plonky2/shaders/poseidon1_hash.wgsl
@@ -1,0 +1,460 @@
+@group(0) @binding(0) var<storage, read_write> output: array<P1HashDigest>;
+@group(0) @binding(1) var<storage, read_write> input: array<BigInt>;
+@group(0) @binding(2) var<storage, read> num: u32;
+@group(0) @binding(3) var<storage, read> elementsPerLeaf: u32;
+@group(0) @binding(4) var<storage, read> mdsCirc: array<BigInt, 12>;
+@group(0) @binding(5) var<storage, read> mdsDiag: array<BigInt, 12>;
+@group(0) @binding(6) var<storage, read> rc: array<BigInt, 360>;
+
+const WORKGROUP_SIZE: u32 = 64u;
+const WORKGROUP_SIZE_Y: u32 = 1u;
+var<private> carry_flag: u32 = 0u;
+const M: BigInt = BigInt(array(u32(1), u32(4294967295)));
+const MontyOne: BigInt = BigInt(array(u32(4294967295), u32(0)));
+const PP1D2: BigInt = BigInt(array(u32(2147483649), u32(2147483647)));
+const M0NInv: u32 = 4294967295;
+const R2modP: BigInt = BigInt(array(u32(1), u32(4294967294)));
+
+struct BigInt {
+  limbs: array<u32, 2>,
+};
+struct P1HashDigest {
+  elems: array<BigInt, 4>,
+};
+
+@compute @workgroup_size(WORKGROUP_SIZE, WORKGROUP_SIZE_Y)
+fn poseidon1Hash(@builtin(local_invocation_id)  local_id : vec3<u32>,      // ≈ CUDA threadIdx
+@builtin(workgroup_id)         workgroup_id: vec3<u32>,   // ≈ CUDA blockIdx
+@builtin(num_workgroups)       num_workgroups: vec3<u32>, // ≈ CUDA gridDim
+@builtin(global_invocation_id) global_id: vec3<u32>,      // = workgroup_id * workgroup_size + local_id
+) {
+  /* Computes a Poseidon1 hash function for `num` input vectors, each of which is `elementsPerLeaf`
+elements long.
+
+The data must be given in a *transposed* layout .
+Let `N` be the total number of inputs and `k` the size of each vector.
+
+[ [ leaf0_0, leaf1_0, ..., leafN_0 ],
+  [ leaf0_1, leaf1_1, ..., leafN_1 ],
+  ...
+  [ leaf0_k, leaf1_k, ..., leafN_k ] ]
+
+This is in contrast to the layout one would normally encounter, corresponding to
+`seq[seq[T]]` where the inner `seq[T]` is each vector to be hashed. */;
+  let grid_width: u32 = (num_workgroups.x * 64u);
+  let tid: u32 = ((u32(global_id.y) * u32(grid_width)) + u32(global_id.x));
+  if ((num <= tid)) {
+    return ;
+  };
+  var state: array<BigInt, 12>;
+  for(var i: u32 = 0u; i < 12; i++) {
+    setZero_lmut((&state[i]));
+  };
+  let numChunks: u32 = (elementsPerLeaf / 8u);
+  for(var i: u32 = 0; i < numChunks; i++) {
+    for(var j: u32 = 0; j < 8; j++) {
+      let elementIdx: u32 = ((i * 8u) + j);
+      let idx: u32 = ((elementIdx * num) + tid);
+      state[j] = input[idx];
+    };
+    poseidonPermuteMutImpl_lmut((&state));
+  };
+  let rem: u32 = (elementsPerLeaf % 8u);
+  for(var j: u32 = 0; j < rem; j++) {
+    let elementIdx: u32 = ((numChunks * 8u) + j);
+    let idx: u32 = ((elementIdx * num) + tid);
+    state[j] = input[idx];
+  };
+  if ((0u < rem)) {
+    poseidonPermuteMutImpl_lmut((&state));
+  };
+
+  { // unrolledIter_i0
+  output[tid].elems[0] = state[0];
+  } // unrolledIter_i0
+
+
+  { // unrolledIter_i1
+  output[tid].elems[1] = state[1];
+  } // unrolledIter_i1
+
+
+  { // unrolledIter_i2
+  output[tid].elems[2] = state[2];
+  } // unrolledIter_i2
+
+
+  { // unrolledIter_i3
+  output[tid].elems[3] = state[3];
+  } // unrolledIter_i3
+
+}
+
+fn setZero_lmut(a: ptr<function, BigInt>) {
+  /* Sets all limbs of the field element to zero in place */;
+  for(var i: u32 = 0u; i < 2; i++) {
+    (*a).limbs[i] = 0u;
+  };
+}
+
+fn poseidonPermuteMutImpl_lmut(state: ptr<function, array<BigInt, 12>>) {
+  /* Main Poseidon permutation - inlined for performance */;
+  var roundCtr: u32 = 0;
+  fullRounds_lmut_lmut(state, (&roundCtr));
+  partialRoundsNaive_lmut_lmut(state, (&roundCtr));
+  fullRounds_lmut_lmut(state, (&roundCtr));
+}
+
+fn fullRounds_lmut_lmut(state: ptr<function, array<BigInt, 12>>, round_ctr: ptr<function, u32>) {
+  for(var i: u32 = 0; i < 4u; i++) {
+    constantLayer_lmut_lmut(state, round_ctr);
+    sboxLayer_lmut(state);
+    mdsLayer_lmut(state);
+    (*round_ctr) = ((*round_ctr) + 1u);
+  };
+}
+
+fn constantLayer_lmut_lmut(state: ptr<function, array<BigInt, 12>>, round_ctr: ptr<function, u32>) {
+  for(var i: u32 = 0; i < 12; i++) {
+    let round_constant: BigInt = rc[(i + (12u * (*round_ctr)))];
+    /* XXX: add canonical u64?
+-> Need to construct Montgomery? We just need to turn round constants into
+Montgomery before! */;
+    add_lmut_l_l((&(*state)[i]), (*state)[i], round_constant);
+  };
+}
+
+fn add_lmut_l_l(r: ptr<function, BigInt>, a: BigInt, b: BigInt) {
+  /* Addition of two finite field elements stored in `a` and `b`.
+The result is stored in `r`. */;
+  (*r) = modadd(a, b, M);
+}
+
+fn modadd(a: BigInt, b: BigInt, M: BigInt) -> BigInt {
+  /* Generate an optimized modular addition kernel
+with parameters `a, b, modulus: Limbs -> Limbs` */;
+  var t: BigInt = BigInt(array<u32, 2>());
+  t.limbs[0] = add_co(a.limbs[0], b.limbs[0]);
+
+  { // unrolledIter_i1
+  t.limbs[1] = add_cio(a.limbs[1], b.limbs[1]);
+  } // unrolledIter_i1
+
+  let overflowedLimbs: u32 = add_ci(0u, 0u);
+  t = finalSubMayOverflow(t, M, overflowedLimbs);
+  return t;
+}
+
+fn add_co(a: u32, b: u32) -> u32 {
+  let result: u32 = (a + b);
+  carry_flag = select(0u, 1u, (result < a));
+  return result;
+}
+
+fn add_cio(a: u32, b: u32) -> u32 {
+  let temp: u32 = (a + b);
+  let result: u32 = (temp + carry_flag);
+  carry_flag = select(0u, 1u, ((temp < a) || (result < temp)));
+  return result;
+}
+
+fn add_ci(a: u32, b: u32) -> u32 {
+  let temp: u32 = (a + b);
+  let result: u32 = (temp + carry_flag);
+  return result;
+}
+
+fn finalSubMayOverflow(a: BigInt, M: BigInt, overflowedLimbs: u32) -> BigInt {
+  /* If a >= Modulus: r <- a-M
+else:            r <- a
+
+This is constant-time straightline code.
+Due to warp divergence, the overhead of doing comparison with shortcutting might not be worth it on GPU.
+
+To be used when the final substraction can
+also overflow the limbs (a 2^256 order of magnitude modulus stored in n words of total max size 2^256) */;
+  var scratch: BigInt = BigInt(array<u32, 2>());
+  scratch.limbs[0] = sub_bo(a.limbs[0], M.limbs[0]);
+
+  { // unrolledIter_i1
+  scratch.limbs[1] = sub_bio(a.limbs[1], M.limbs[1]);
+  } // unrolledIter_i1
+
+  let underflowedModulus: u32 = sub_bi(overflowedLimbs, 0u);
+  var r: BigInt = BigInt(array<u32, 2>());
+
+  { // unrolledIter_i0
+  r.limbs[0] = slct(scratch.limbs[0], a.limbs[0], bitcast<i32>(underflowedModulus));
+  } // unrolledIter_i0
+
+
+  { // unrolledIter_i1
+  r.limbs[1] = slct(scratch.limbs[1], a.limbs[1], bitcast<i32>(underflowedModulus));
+  } // unrolledIter_i1
+
+  return r;
+}
+
+fn sub_bo(a: u32, b: u32) -> u32 {
+  let result: u32 = (a - b);
+  carry_flag = select(0u, 1u, (a < b));
+  return result;
+}
+
+fn sub_bio(a: u32, b: u32) -> u32 {
+  let temp: u32 = (a - b);
+  let result: u32 = (temp - carry_flag);
+  carry_flag = select(0u, 1u, ((a < b) || (temp < carry_flag)));
+  return result;
+}
+
+fn sub_bi(a: u32, b: u32) -> u32 {
+  let temp: u32 = (a - b);
+  let result: u32 = (temp - carry_flag);
+  return result;
+}
+
+fn slct(a: u32, b: u32, pred: i32) -> u32 {
+  return select(b, a, (0 <= pred));
+}
+
+fn sboxLayer_lmut(state: ptr<function, array<BigInt, 12>>) {
+  for(var i: u32 = 0; i < 12; i++) {
+    (*state)[i] = sboxMonomial((*state)[i]);
+  };
+}
+
+fn sboxMonomial(x: BigInt) -> BigInt {
+  var x2: BigInt;
+  var x3: BigInt;
+  var x4: BigInt;
+  mul_lmut_l_l((&x2), x, x);
+  mul_lmut_l_l((&x4), x2, x2);
+  mul_lmut_l_l((&x3), x, x2);
+  mul_lmut_l_l((&x2), x3, x4);
+  return x2;
+}
+
+fn mul_lmut_l_l(r: ptr<function, BigInt>, a: BigInt, b: BigInt) {
+  /* Multiplication of two finite field elements stored in `a` and `b`.
+The result is stored in `r`. */;
+  (*r) = mtymul_FIPS___f4FuSyv5EILd5KB2IIWyig(a, b, M, false);
+}
+
+fn mtymul_FIPS___f4FuSyv5EILd5KB2IIWyig(a: BigInt, b: BigInt, M: BigInt, lazyReduce: bool) -> BigInt {
+  /* Montgomery Multiplication using Finely Integrated Product Scanning (FIPS).
+This implementation can be used for fields that do not have any spare bits.
+
+This maps
+- [0, 2p) -> [0, 2p) with lazyReduce
+- [0, 2p) -> [0, p) without
+
+lazyReduce skips the final substraction step. */;
+;
+  var z: BigInt = BigInt(array<u32, 2>());
+  const L: i32 = 2;
+  var t: u32 = 0u;
+  var u: u32 = 0u;
+  var v: u32 = 0u;
+
+  { // unrolledIter_i0
+
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), a.limbs[0], b.limbs[0]);
+  z.limbs[0] = (v * 4294967295u);
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), z.limbs[0], M.limbs[0]);
+  v = u;
+  u = t;
+  t = 0u;
+  } // unrolledIter_i0
+
+
+  { // unrolledIter_i1
+
+  { // unrolledIter_j0
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), a.limbs[0], b.limbs[1]);
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), z.limbs[0], M.limbs[1]);
+  } // unrolledIter_j0
+
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), a.limbs[1], b.limbs[0]);
+  z.limbs[1] = (v * 4294967295u);
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), z.limbs[1], M.limbs[0]);
+  v = u;
+  u = t;
+  t = 0u;
+  } // unrolledIter_i1
+
+
+  { // unrolledIter_i2
+
+  { // unrolledIter_j1
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), a.limbs[1], b.limbs[1]);
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), z.limbs[1], M.limbs[1]);
+  } // unrolledIter_j1
+
+  z.limbs[0] = v;
+  v = u;
+  u = t;
+  t = 0u;
+  } // unrolledIter_i2
+
+
+  { // unrolledIter_i3
+
+  z.limbs[1] = v;
+  v = u;
+  u = t;
+  t = 0u;
+  } // unrolledIter_i3
+
+  let cond: bool = (!(v == 0u) || !less(z, M));
+  csub_no_mod_lmut_l_l((&z), M, cond);
+  return z;
+}
+
+fn mulAcc_lmut_lmut_lmut_l_l(t: ptr<function, u32>, u: ptr<function, u32>, v: ptr<function, u32>, a: u32, b: u32) {
+  /* (t, u, v) <- (t, u, v) + a * b */;
+  (*v) = mulloadd_co(a, b, (*v));
+  (*u) = mulhiadd_cio(a, b, (*u));
+  (*t) = add_ci((*t), 0u);
+}
+
+fn mulloadd_co(a: u32, b: u32, c: u32) -> u32 {
+  /* Multiply-add low with carry out */;
+  let product: u32 = mul_lo(a, b);
+  return add_co(product, c);
+}
+
+fn mul_lo(a: u32, b: u32) -> u32 {
+  /* Returns the lower 32 bit of the uint32 multiplication
+Native WGSL multiplication automatically wraps to 32 bits */;
+  return (a * b);
+}
+
+fn mulhiadd_cio(a: u32, b: u32, c: u32) -> u32 {
+  /* Multiply-add high with carry in and carry out */;
+  let hi_product: u32 = mul_hi(a, b);
+  return add_cio(hi_product, c);
+}
+
+fn mul_hi(a: u32, b: u32) -> u32 {
+  /* Returns the upper 32 bit of the uint32 multiplication
+Decompose into 16-bit chunks to avoid overflow */;
+  let a_lo: u32 = (a & 65535u);
+  let a_hi: u32 = (a >> 16);
+  let b_lo: u32 = (b & 65535u);
+  let b_hi: u32 = (b >> 16);
+  let p0: u32 = (a_lo * b_lo);
+  let p1: u32 = (a_lo * b_hi);
+  let p2: u32 = (a_hi * b_lo);
+  let p3: u32 = (a_hi * b_hi);
+  let middle: u32 = (((p0 >> 16) + (p1 & 65535u)) + (p2 & 65535u));
+  let carry: u32 = (middle >> 16);
+  return (((p3 + (p1 >> 16)) + (p2 >> 16)) + carry);
+}
+
+fn less(a: BigInt, b: BigInt) -> bool {
+  /* Returns true if a < b for two big ints in *canonical*
+representation.
+
+NOTE: The inputs are compared *as is*. That means if they are
+in Montgomery representation the result will not reflect the
+ordering relation of their associated canonical values!
+Call `toCanonical` on field elements in Montgomery order before
+comparing them.
+
+Comparison is constant-time */;
+  var borrow: u32;
+  sub_bo(a.limbs[0], b.limbs[0]);
+
+  { // unrolledIter_i1
+  sub_bio(a.limbs[1], b.limbs[1]);
+  } // unrolledIter_i1
+
+  borrow = sub_bi(0u, 0u);
+  return bool(borrow);
+}
+
+fn csub_no_mod_lmut_l_l(r: ptr<function, BigInt>, a: BigInt, condition: bool) {
+  /* Conditionally subtract `a` from `r` in place *without* modular
+reduction.
+
+Note: This is constant-time */;
+  var t: BigInt = BigInt(array<u32, 2>());
+  sub_no_mod___d9cpFFTTlwIJez0po9bQ0J4g_lmut_l_l((&t), (*r), a);
+  ccopy___HjzYt6G86OUE1KbkDccyqg_lmut_l_l(r, t, condition);
+}
+
+fn sub_no_mod___d9cpFFTTlwIJez0po9bQ0J4g_lmut_l_l(r: ptr<function, BigInt>, a: BigInt, b: BigInt) {
+  /* Subtraction of two finite field elements stored in `a` and `b`
+*without* modular reduction.
+The result is stored in `r`. */;
+  (*r) = sub_no_mod(a, b);
+}
+
+fn sub_no_mod(a: BigInt, b: BigInt) -> BigInt {
+  /* Generate an optimized substraction kernel
+with parameters `a, b, modulus: Limbs -> Limbs`
+I.e. this does _not_ perform modular reduction. */;
+  var t: BigInt = BigInt(array<u32, 2>());
+  t.limbs[0] = sub_bo(a.limbs[0], b.limbs[0]);
+
+  { // unrolledIter_i1
+  t.limbs[1] = sub_bio(a.limbs[1], b.limbs[1]);
+  } // unrolledIter_i1
+
+  return t;
+}
+
+fn ccopy___HjzYt6G86OUE1KbkDccyqg_lmut_l_l(a: ptr<function, BigInt>, b: BigInt, condition: bool) {
+  /* Conditional copy.
+If condition is true: b is copied into a
+If condition is false: a is left unmodified
+
+Note: This is constant-time */;
+  /* XXX: add support for `IfExpr`! Requires though. */;
+  var cond: i32;
+  if (condition) {
+    cond = 1;
+  } else {
+    cond = -1;
+  };
+  for(var i: u32 = 0u; i < 2; i++) {
+    (*a).limbs[i] = slct(b.limbs[i], (*a).limbs[i], cond);
+  };
+}
+
+fn mdsLayer_lmut(state: ptr<function, array<BigInt, 12>>) {
+  /* XXX: Return copy? Better mutate in place?
+XXX: We could consider an implementation closer to the regular implementation
+Plonky2 uses for generic fields. But that requires us to implement a `u128` type
+with _at least_ multiplication. */;
+  var tmp: array<BigInt, 12>;
+  /* XXX: avoid this copy? */;
+  tmp = (*state);
+  for(var r: u32 = 0; r < 12; r++) {
+    /* XXX: pass by reference! */;
+    (*state)[r] = mdsRowShfNaive(r, tmp);
+  };
+}
+
+fn mdsRowShfNaive(r: u32, v: array<BigInt, 12>) -> BigInt {
+  var res: BigInt = BigInt(array<u32, 2>());
+  var val: BigInt;
+  for(var i: u32 = 0; i < 12; i++) {
+    mul_lmut_l_l((&val), v[((i + r) % 12u)], mdsCirc[i]);
+    add_lmut_l_l((&res), res, val);
+  };
+  mul_lmut_l_l((&val), v[r], mdsDiag[r]);
+  add_lmut_l_l((&res), res, val);
+  return res;
+}
+
+fn partialRoundsNaive_lmut_lmut(state: ptr<function, array<BigInt, 12>>, round_ctr: ptr<function, u32>) {
+  for(var i: u32 = 0; i < 22u; i++) {
+    constantLayer_lmut_lmut(state, round_ctr);
+    (*state)[0] = sboxMonomial((*state)[0]);
+    mdsLayer_lmut(state);
+    (*round_ctr) = ((*round_ctr) + 1u);
+  };
+}
+

--- a/plonky2/shaders/transpose_to_montgomery.wgsl
+++ b/plonky2/shaders/transpose_to_montgomery.wgsl
@@ -1,0 +1,275 @@
+@group(0) @binding(0) var<storage, read_write> dst: array<BigInt>;
+@group(0) @binding(1) var<storage, read_write> src: array<BigInt>;
+@group(0) @binding(2) var<storage, read> numLeaves: u32;
+@group(0) @binding(3) var<storage, read> elemsPerLeaf: u32;
+
+const WORKGROUP_SIZE: u32 = 16u;
+const WORKGROUP_SIZE_Y: u32 = 16u;
+var<private> carry_flag: u32 = 0u;
+const M: BigInt = BigInt(array(u32(1), u32(4294967295)));
+const MontyOne: BigInt = BigInt(array(u32(4294967295), u32(0)));
+const PP1D2: BigInt = BigInt(array(u32(2147483649), u32(2147483647)));
+const M0NInv: u32 = 4294967295;
+const R2modP: BigInt = BigInt(array(u32(1), u32(4294967294)));
+const TILE_R: i32 = 16;
+const TILE_C: i32 = 16;
+const TILE_R_1: i32 = 17;
+var<workgroup> tile: array<array<BigInt, 17>, 16>;
+
+struct BigInt {
+  limbs: array<u32, 2>,
+};
+
+@compute @workgroup_size(WORKGROUP_SIZE, WORKGROUP_SIZE_Y)
+fn transposeNaive(@builtin(local_invocation_id)  local_id : vec3<u32>,      // ≈ CUDA threadIdx
+@builtin(workgroup_id)         workgroup_id: vec3<u32>,   // ≈ CUDA blockIdx
+@builtin(num_workgroups)       num_workgroups: vec3<u32>, // ≈ CUDA gridDim
+@builtin(global_invocation_id) global_id: vec3<u32>,      // = workgroup_id * workgroup_size + local_id
+) {
+  let row: u32 = u32(global_id.y);
+  let col: u32 = u32(global_id.x);
+  if (((row < numLeaves) && (col < elemsPerLeaf))) {
+    let v: BigInt = src[((row * elemsPerLeaf) + col)];
+    dst[((col * numLeaves) + row)] = getMont(v);
+  };
+}
+
+fn getMont(b: BigInt) -> BigInt {
+  var result: BigInt;
+  /* Transform a bigint ``a`` from it's natural representation (mod N)
+to a the Montgomery n-residue representation
+
+Montgomery-Multiplication - based
+
+with W = M.len
+and R = (2^WordBitWidth)^W
+
+Does "a * R (mod M)" */;
+  result = mtymul_FIPS___f4FuSyv5EILd5KB2IIWyig(b, R2modP, M, false);
+  return result;
+}
+
+fn mtymul_FIPS___f4FuSyv5EILd5KB2IIWyig(a: BigInt, b: BigInt, M: BigInt, lazyReduce: bool) -> BigInt {
+  /* Montgomery Multiplication using Finely Integrated Product Scanning (FIPS).
+This implementation can be used for fields that do not have any spare bits.
+
+This maps
+- [0, 2p) -> [0, 2p) with lazyReduce
+- [0, 2p) -> [0, p) without
+
+lazyReduce skips the final substraction step. */;
+;
+  var z: BigInt = BigInt(array<u32, 2>());
+  const L: i32 = 2;
+  var t: u32 = 0u;
+  var u: u32 = 0u;
+  var v: u32 = 0u;
+
+  { // unrolledIter_i0
+
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), a.limbs[0], b.limbs[0]);
+  z.limbs[0] = (v * 4294967295u);
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), z.limbs[0], M.limbs[0]);
+  v = u;
+  u = t;
+  t = 0u;
+  } // unrolledIter_i0
+
+
+  { // unrolledIter_i1
+
+  { // unrolledIter_j0
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), a.limbs[0], b.limbs[1]);
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), z.limbs[0], M.limbs[1]);
+  } // unrolledIter_j0
+
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), a.limbs[1], b.limbs[0]);
+  z.limbs[1] = (v * 4294967295u);
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), z.limbs[1], M.limbs[0]);
+  v = u;
+  u = t;
+  t = 0u;
+  } // unrolledIter_i1
+
+
+  { // unrolledIter_i2
+
+  { // unrolledIter_j1
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), a.limbs[1], b.limbs[1]);
+  mulAcc_lmut_lmut_lmut_l_l((&t), (&u), (&v), z.limbs[1], M.limbs[1]);
+  } // unrolledIter_j1
+
+  z.limbs[0] = v;
+  v = u;
+  u = t;
+  t = 0u;
+  } // unrolledIter_i2
+
+
+  { // unrolledIter_i3
+
+  z.limbs[1] = v;
+  v = u;
+  u = t;
+  t = 0u;
+  } // unrolledIter_i3
+
+  let cond: bool = (!(v == 0u) || !less(z, M));
+  csub_no_mod_lmut_l_l((&z), M, cond);
+  return z;
+}
+
+fn mulAcc_lmut_lmut_lmut_l_l(t: ptr<function, u32>, u: ptr<function, u32>, v: ptr<function, u32>, a: u32, b: u32) {
+  /* (t, u, v) <- (t, u, v) + a * b */;
+  (*v) = mulloadd_co(a, b, (*v));
+  (*u) = mulhiadd_cio(a, b, (*u));
+  (*t) = add_ci((*t), 0u);
+}
+
+fn mulloadd_co(a: u32, b: u32, c: u32) -> u32 {
+  /* Multiply-add low with carry out */;
+  let product: u32 = mul_lo(a, b);
+  return add_co(product, c);
+}
+
+fn mul_lo(a: u32, b: u32) -> u32 {
+  /* Returns the lower 32 bit of the uint32 multiplication
+Native WGSL multiplication automatically wraps to 32 bits */;
+  return (a * b);
+}
+
+fn add_co(a: u32, b: u32) -> u32 {
+  let result: u32 = (a + b);
+  carry_flag = select(0u, 1u, (result < a));
+  return result;
+}
+
+fn mulhiadd_cio(a: u32, b: u32, c: u32) -> u32 {
+  /* Multiply-add high with carry in and carry out */;
+  let hi_product: u32 = mul_hi(a, b);
+  return add_cio(hi_product, c);
+}
+
+fn mul_hi(a: u32, b: u32) -> u32 {
+  /* Returns the upper 32 bit of the uint32 multiplication
+Decompose into 16-bit chunks to avoid overflow */;
+  let a_lo: u32 = (a & 65535u);
+  let a_hi: u32 = (a >> 16);
+  let b_lo: u32 = (b & 65535u);
+  let b_hi: u32 = (b >> 16);
+  let p0: u32 = (a_lo * b_lo);
+  let p1: u32 = (a_lo * b_hi);
+  let p2: u32 = (a_hi * b_lo);
+  let p3: u32 = (a_hi * b_hi);
+  let middle: u32 = (((p0 >> 16) + (p1 & 65535u)) + (p2 & 65535u));
+  let carry: u32 = (middle >> 16);
+  return (((p3 + (p1 >> 16)) + (p2 >> 16)) + carry);
+}
+
+fn add_cio(a: u32, b: u32) -> u32 {
+  let temp: u32 = (a + b);
+  let result: u32 = (temp + carry_flag);
+  carry_flag = select(0u, 1u, ((temp < a) || (result < temp)));
+  return result;
+}
+
+fn add_ci(a: u32, b: u32) -> u32 {
+  let temp: u32 = (a + b);
+  let result: u32 = (temp + carry_flag);
+  return result;
+}
+
+fn less(a: BigInt, b: BigInt) -> bool {
+  /* Returns true if a < b for two big ints in *canonical*
+representation.
+
+NOTE: The inputs are compared *as is*. That means if they are
+in Montgomery representation the result will not reflect the
+ordering relation of their associated canonical values!
+Call `toCanonical` on field elements in Montgomery order before
+comparing them.
+
+Comparison is constant-time */;
+  var borrow: u32;
+  sub_bo(a.limbs[0], b.limbs[0]);
+
+  { // unrolledIter_i1
+  sub_bio(a.limbs[1], b.limbs[1]);
+  } // unrolledIter_i1
+
+  borrow = sub_bi(0u, 0u);
+  return bool(borrow);
+}
+
+fn sub_bo(a: u32, b: u32) -> u32 {
+  let result: u32 = (a - b);
+  carry_flag = select(0u, 1u, (a < b));
+  return result;
+}
+
+fn sub_bio(a: u32, b: u32) -> u32 {
+  let temp: u32 = (a - b);
+  let result: u32 = (temp - carry_flag);
+  carry_flag = select(0u, 1u, ((a < b) || (temp < carry_flag)));
+  return result;
+}
+
+fn sub_bi(a: u32, b: u32) -> u32 {
+  let temp: u32 = (a - b);
+  let result: u32 = (temp - carry_flag);
+  return result;
+}
+
+fn csub_no_mod_lmut_l_l(r: ptr<function, BigInt>, a: BigInt, condition: bool) {
+  /* Conditionally subtract `a` from `r` in place *without* modular
+reduction.
+
+Note: This is constant-time */;
+  var t: BigInt = BigInt(array<u32, 2>());
+  sub_no_mod___d9cpFFTTlwIJez0po9bQ0J4g_lmut_l_l((&t), (*r), a);
+  ccopy___HjzYt6G86OUE1KbkDccyqg_lmut_l_l(r, t, condition);
+}
+
+fn sub_no_mod___d9cpFFTTlwIJez0po9bQ0J4g_lmut_l_l(r: ptr<function, BigInt>, a: BigInt, b: BigInt) {
+  /* Subtraction of two finite field elements stored in `a` and `b`
+*without* modular reduction.
+The result is stored in `r`. */;
+  (*r) = sub_no_mod(a, b);
+}
+
+fn sub_no_mod(a: BigInt, b: BigInt) -> BigInt {
+  /* Generate an optimized substraction kernel
+with parameters `a, b, modulus: Limbs -> Limbs`
+I.e. this does _not_ perform modular reduction. */;
+  var t: BigInt = BigInt(array<u32, 2>());
+  t.limbs[0] = sub_bo(a.limbs[0], b.limbs[0]);
+
+  { // unrolledIter_i1
+  t.limbs[1] = sub_bio(a.limbs[1], b.limbs[1]);
+  } // unrolledIter_i1
+
+  return t;
+}
+
+fn ccopy___HjzYt6G86OUE1KbkDccyqg_lmut_l_l(a: ptr<function, BigInt>, b: BigInt, condition: bool) {
+  /* Conditional copy.
+If condition is true: b is copied into a
+If condition is false: a is left unmodified
+
+Note: This is constant-time */;
+  /* XXX: add support for `IfExpr`! Requires though. */;
+  var cond: i32;
+  if (condition) {
+    cond = 1;
+  } else {
+    cond = -1;
+  };
+  for(var i: u32 = 0u; i < 2; i++) {
+    (*a).limbs[i] = slct(b.limbs[i], (*a).limbs[i], cond);
+  };
+}
+
+fn slct(a: u32, b: u32, pred: i32) -> u32 {
+  return select(b, a, (0 <= pred));
+}
+

--- a/plonky2/src/fri/oracle.rs
+++ b/plonky2/src/fri/oracle.rs
@@ -342,7 +342,15 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         }
         #[cfg(not(feature = "std"))]
         {
-            panic!("PolynomialBatch::prove_openings requires the `std` feature when async proving is enabled");
+            crate::util::nostd_block_on(Self::prove_openings_async(
+                instance,
+                oracles,
+                challenger,
+                fri_params,
+                final_poly_coeff_len,
+                max_num_query_steps,
+                timing,
+            ))
         }
     }
 

--- a/plonky2/src/fri/oracle.rs
+++ b/plonky2/src/fri/oracle.rs
@@ -1,14 +1,14 @@
 #[cfg(not(feature = "std"))]
 use alloc::{format, vec::Vec};
 
+use itertools::Itertools;
+use plonky2_field::types::Field;
+use plonky2_maybe_rayon::*;
 #[cfg(all(
     feature = "std",
     not(all(feature = "gpu_merkle", target_arch = "wasm32"))
 ))]
 use pollster::block_on;
-use itertools::Itertools;
-use plonky2_field::types::Field;
-use plonky2_maybe_rayon::*;
 
 use crate::field::extension::Extendable;
 use crate::field::fft::FftRootTable;

--- a/plonky2/src/fri/oracle.rs
+++ b/plonky2/src/fri/oracle.rs
@@ -1,6 +1,11 @@
 #[cfg(not(feature = "std"))]
 use alloc::{format, vec::Vec};
 
+#[cfg(all(
+    feature = "std",
+    not(all(feature = "gpu_merkle", target_arch = "wasm32"))
+))]
+use futures::executor::block_on;
 use itertools::Itertools;
 use plonky2_field::types::Field;
 use plonky2_maybe_rayon::*;
@@ -10,7 +15,7 @@ use crate::field::fft::FftRootTable;
 use crate::field::packed::PackedField;
 use crate::field::polynomial::{PolynomialCoeffs, PolynomialValues};
 use crate::fri::proof::FriProof;
-use crate::fri::prover::fri_proof;
+use crate::fri::prover::fri_proof_async;
 use crate::fri::structure::{FriBatchInfo, FriInstanceInfo};
 use crate::fri::FriParams;
 use crate::hash::hash_types::RichField;
@@ -18,6 +23,7 @@ use crate::hash::merkle_tree::MerkleTree;
 use crate::iop::challenger::Challenger;
 use crate::plonk::config::GenericConfig;
 use crate::timed;
+use crate::util::profiling::{with_timer, with_timer_async};
 use crate::util::reducing::ReducingFactor;
 use crate::util::timing::TimingTree;
 use crate::util::{log2_strict, reverse_bits, reverse_index_bits_in_place, transpose};
@@ -62,11 +68,9 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         timing: &mut TimingTree,
         fft_root_table: Option<&FftRootTable<F>>,
     ) -> Self {
-        let coeffs = timed!(
-            timing,
-            "IFFT",
+        let coeffs = with_timer("PolynomialBatch::from_values IFFT", move || {
             values.into_par_iter().map(|v| v.ifft()).collect::<Vec<_>>()
-        );
+        });
 
         Self::from_coeffs(
             coeffs,
@@ -76,6 +80,29 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
             timing,
             fft_root_table,
         )
+    }
+
+    pub async fn from_values_async(
+        values: Vec<PolynomialValues<F>>,
+        rate_bits: usize,
+        blinding: bool,
+        cap_height: usize,
+        timing: &mut TimingTree,
+        fft_root_table: Option<&FftRootTable<F>>,
+    ) -> Self {
+        let coeffs = with_timer("PolynomialBatch::from_values_async IFFT", move || {
+            values.into_par_iter().map(|v| v.ifft()).collect::<Vec<_>>()
+        });
+
+        Self::from_coeffs_async(
+            coeffs,
+            rate_bits,
+            blinding,
+            cap_height,
+            timing,
+            fft_root_table,
+        )
+        .await
     }
 
     /// Creates a list polynomial commitment for the polynomials `polynomials`.
@@ -88,14 +115,59 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         fft_root_table: Option<&FftRootTable<F>>,
     ) -> Self {
         let degree = polynomials[0].len();
-        let lde_values = timed!(
-            timing,
-            "FFT + blinding",
+        let lde_values = with_timer("PolynomialBatch::from_coeffs FFT", || {
             Self::lde_values(&polynomials, rate_bits, blinding, fft_root_table)
+        });
+
+        let mut leaves = with_timer("PolynomialBatch::transpose LDEs", || {
+            timed!(timing, "transpose LDEs", transpose(&lde_values))
+        });
+        with_timer("PolynomialBatch::bit-reverse leaves", || {
+            reverse_index_bits_in_place(&mut leaves);
+        });
+        let merkle_tree = timed!(
+            timing,
+            "build Merkle tree",
+            MerkleTree::new(leaves, cap_height)
         );
 
-        let mut leaves = timed!(timing, "transpose LDEs", transpose(&lde_values));
-        reverse_index_bits_in_place(&mut leaves);
+        Self {
+            polynomials,
+            merkle_tree,
+            degree_log: log2_strict(degree),
+            rate_bits,
+            blinding,
+        }
+    }
+
+    pub async fn from_coeffs_async(
+        polynomials: Vec<PolynomialCoeffs<F>>,
+        rate_bits: usize,
+        blinding: bool,
+        cap_height: usize,
+        timing: &mut TimingTree,
+        fft_root_table: Option<&FftRootTable<F>>,
+    ) -> Self {
+        let degree = polynomials[0].len();
+        let lde_values = with_timer("PolynomialBatch::from_coeffs_async FFT", || {
+            Self::lde_values(&polynomials, rate_bits, blinding, fft_root_table)
+        });
+
+        let mut leaves = with_timer("PolynomialBatch::transpose LDEs", || {
+            timed!(timing, "transpose LDEs", transpose(&lde_values))
+        });
+        with_timer("PolynomialBatch::bit-reverse leaves", || {
+            reverse_index_bits_in_place(&mut leaves);
+        });
+
+        #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+        let merkle_tree = timed!(
+            timing,
+            "build Merkle tree",
+            MerkleTree::new_async(leaves, cap_height).await
+        );
+
+        #[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
         let merkle_tree = timed!(
             timing,
             "build Merkle tree",
@@ -173,7 +245,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     }
 
     /// Produces a batch opening proof.
-    pub fn prove_openings(
+    pub async fn prove_openings_async(
         instance: &FriInstanceInfo<F, D>,
         oracles: &[&Self],
         challenger: &mut Challenger<F, C::Hasher>,
@@ -196,43 +268,90 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         // where the `k_i`s are chosen such that each power of `alpha` appears only once in the final sum.
         // There are usually two batches for the openings at `zeta` and `g * zeta`.
         // The oracles used in Plonky2 are given in `FRI_ORACLES` in `plonky2/src/plonk/plonk_common.rs`.
-        for FriBatchInfo { point, polynomials } in &instance.batches {
-            // Collect the coefficients of all the polynomials in `polynomials`.
-            let polys_coeff = polynomials.iter().map(|fri_poly| {
-                &oracles[fri_poly.oracle_index].polynomials[fri_poly.polynomial_index]
-            });
-            let composition_poly = timed!(
+        with_timer("FRI combine opening batches", || {
+            for FriBatchInfo { point, polynomials } in &instance.batches {
+                // Collect the coefficients of all the polynomials in `polynomials`.
+                let polys_coeff = polynomials.iter().map(|fri_poly| {
+                    &oracles[fri_poly.oracle_index].polynomials[fri_poly.polynomial_index]
+                });
+                let composition_poly = timed!(
+                    timing,
+                    &format!("reduce batch of {} polynomials", polynomials.len()),
+                    alpha.reduce_polys_base(polys_coeff)
+                );
+                let mut quotient = composition_poly.divide_by_linear(*point);
+                quotient.coeffs.push(F::Extension::ZERO); // pad back to power of two
+                alpha.shift_poly(&mut final_poly);
+                final_poly += quotient;
+            }
+        });
+
+        let lde_final_poly = with_timer("FRI final polynomial LDE", || {
+            final_poly.lde(fri_params.config.rate_bits)
+        });
+        let lde_final_values = with_timer("FRI final FFT", || {
+            timed!(
                 timing,
-                &format!("reduce batch of {} polynomials", polynomials.len()),
-                alpha.reduce_polys_base(polys_coeff)
-            );
-            let mut quotient = composition_poly.divide_by_linear(*point);
-            quotient.coeffs.push(F::Extension::ZERO); // pad back to power of two
-            alpha.shift_poly(&mut final_poly);
-            final_poly += quotient;
-        }
+                &format!("perform final FFT {}", lde_final_poly.len()),
+                lde_final_poly.coset_fft(F::coset_shift().into())
+            )
+        });
 
-        let lde_final_poly = final_poly.lde(fri_params.config.rate_bits);
-        let lde_final_values = timed!(
-            timing,
-            &format!("perform final FFT {}", lde_final_poly.len()),
-            lde_final_poly.coset_fft(F::coset_shift().into())
-        );
-
-        let fri_proof = fri_proof::<F, C, D>(
-            &oracles
-                .par_iter()
-                .map(|c| &c.merkle_tree)
-                .collect::<Vec<_>>(),
-            lde_final_poly,
-            lde_final_values,
-            challenger,
-            fri_params,
-            final_poly_coeff_len,
-            max_num_query_steps,
-            timing,
-        );
+        let fri_proof = with_timer_async("FRI prove openings", || async {
+            fri_proof_async::<F, C, D>(
+                &oracles
+                    .par_iter()
+                    .map(|c| &c.merkle_tree)
+                    .collect::<Vec<_>>(),
+                lde_final_poly,
+                lde_final_values,
+                challenger,
+                fri_params,
+                final_poly_coeff_len,
+                max_num_query_steps,
+                timing,
+            )
+            .await
+        })
+        .await;
 
         fri_proof
+    }
+
+    #[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
+    pub fn prove_openings(
+        instance: &FriInstanceInfo<F, D>,
+        oracles: &[&Self],
+        challenger: &mut Challenger<F, C::Hasher>,
+        fri_params: &FriParams,
+        timing: &mut TimingTree,
+    ) -> FriProof<F, C::Hasher, D> {
+        #[cfg(feature = "std")]
+        {
+            return block_on(Self::prove_openings_async(
+                instance, oracles, challenger, fri_params, timing,
+            ));
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            panic!("PolynomialBatch::prove_openings requires the `std` feature when async proving is enabled");
+        }
+    }
+
+    #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+    #[track_caller]
+    pub fn prove_openings(
+        _instance: &FriInstanceInfo<F, D>,
+        _oracles: &[&Self],
+        _challenger: &mut Challenger<F, C::Hasher>,
+        _fri_params: &FriParams,
+        _timing: &mut TimingTree,
+    ) -> FriProof<F, C::Hasher, D> {
+        let caller = core::panic::Location::caller();
+        panic!(
+            "prove_openings must be awaited on wasm with gpu_merkle enabled (caller: {}:{})",
+            caller.file(),
+            caller.line()
+        );
     }
 }

--- a/plonky2/src/fri/oracle.rs
+++ b/plonky2/src/fri/oracle.rs
@@ -330,7 +330,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     ) -> FriProof<F, C::Hasher, D> {
         #[cfg(feature = "std")]
         {
-            return block_on(Self::prove_openings_async(
+            block_on(Self::prove_openings_async(
                 instance,
                 oracles,
                 challenger,
@@ -338,7 +338,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
                 final_poly_coeff_len,
                 max_num_query_steps,
                 timing,
-            ));
+            ))
         }
         #[cfg(not(feature = "std"))]
         {

--- a/plonky2/src/fri/oracle.rs
+++ b/plonky2/src/fri/oracle.rs
@@ -324,12 +324,20 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         oracles: &[&Self],
         challenger: &mut Challenger<F, C::Hasher>,
         fri_params: &FriParams,
+        final_poly_coeff_len: Option<usize>,
+        max_num_query_steps: Option<usize>,
         timing: &mut TimingTree,
     ) -> FriProof<F, C::Hasher, D> {
         #[cfg(feature = "std")]
         {
             return block_on(Self::prove_openings_async(
-                instance, oracles, challenger, fri_params, timing,
+                instance,
+                oracles,
+                challenger,
+                fri_params,
+                final_poly_coeff_len,
+                max_num_query_steps,
+                timing,
             ));
         }
         #[cfg(not(feature = "std"))]
@@ -345,6 +353,8 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         _oracles: &[&Self],
         _challenger: &mut Challenger<F, C::Hasher>,
         _fri_params: &FriParams,
+        _final_poly_coeff_len: Option<usize>,
+        _max_num_query_steps: Option<usize>,
         _timing: &mut TimingTree,
     ) -> FriProof<F, C::Hasher, D> {
         let caller = core::panic::Location::caller();

--- a/plonky2/src/fri/oracle.rs
+++ b/plonky2/src/fri/oracle.rs
@@ -5,7 +5,7 @@ use alloc::{format, vec::Vec};
     feature = "std",
     not(all(feature = "gpu_merkle", target_arch = "wasm32"))
 ))]
-use futures::executor::block_on;
+use pollster::block_on;
 use itertools::Itertools;
 use plonky2_field::types::Field;
 use plonky2_maybe_rayon::*;

--- a/plonky2/src/fri/prover.rs
+++ b/plonky2/src/fri/prover.rs
@@ -4,12 +4,12 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use plonky2_field::types::Field;
+use plonky2_maybe_rayon::*;
 #[cfg(all(
     feature = "std",
     not(all(feature = "gpu_merkle", target_arch = "wasm32"))
 ))]
 use pollster::block_on;
-use plonky2_maybe_rayon::*;
 
 use crate::field::extension::{flatten, unflatten, Extendable};
 use crate::field::polynomial::{PolynomialCoeffs, PolynomialValues};

--- a/plonky2/src/fri/prover.rs
+++ b/plonky2/src/fri/prover.rs
@@ -4,6 +4,11 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use plonky2_field::types::Field;
+#[cfg(all(
+    feature = "std",
+    not(all(feature = "gpu_merkle", target_arch = "wasm32"))
+))]
+use futures::executor::block_on;
 use plonky2_maybe_rayon::*;
 
 use crate::field::extension::{flatten, unflatten, Extendable};
@@ -17,11 +22,16 @@ use crate::iop::challenger::Challenger;
 use crate::plonk::config::GenericConfig;
 use crate::plonk::plonk_common::reduce_with_powers;
 use crate::timed;
+use crate::util::profiling::{with_timer, with_timer_async};
 use crate::util::reverse_index_bits_in_place;
 use crate::util::timing::TimingTree;
 
-/// Builds a FRI proof.
-pub fn fri_proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
+/// Builds a FRI proof asynchronously.
+pub async fn fri_proof_async<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+>(
     initial_merkle_trees: &[&MerkleTree<F, C::Hasher>],
     // Coefficients of the polynomial on which the LDT is performed. Only the first `1/rate` coefficients are non-zero.
     lde_polynomial_coeffs: PolynomialCoeffs<F::Extension>,
@@ -37,29 +47,36 @@ pub fn fri_proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const
     assert_eq!(lde_polynomial_coeffs.len(), n);
 
     // Commit phase
-    let (trees, final_coeffs) = timed!(
-        timing,
-        "fold codewords in the commitment phase",
-        fri_committed_trees::<F, C, D>(
-            lde_polynomial_coeffs,
-            lde_polynomial_values,
-            challenger,
-            fri_params,
-            final_poly_coeff_len,
-            max_num_query_steps,
+    let (trees, final_coeffs) = with_timer_async("FRI commit phase", || async {
+        timed!(
+            timing,
+            "fold codewords in the commitment phase",
+            fri_committed_trees_async::<F, C, D>(
+                lde_polynomial_coeffs,
+                lde_polynomial_values,
+                challenger,
+                fri_params,
+                final_poly_coeff_len,
+                max_num_query_steps,
+            )
+            .await
         )
-    );
+    })
+    .await;
 
     // PoW phase
-    let pow_witness = timed!(
-        timing,
-        "find proof-of-work witness",
-        fri_proof_of_work::<F, C, D>(challenger, &fri_params.config)
-    );
+    let pow_witness = with_timer("FRI proof-of-work", || {
+        timed!(
+            timing,
+            "find proof-of-work witness",
+            fri_proof_of_work::<F, C, D>(challenger, &fri_params.config)
+        )
+    });
 
     // Query phase
-    let query_round_proofs =
-        fri_prover_query_rounds::<F, C, D>(initial_merkle_trees, &trees, challenger, n, fri_params);
+    let query_round_proofs = with_timer("FRI query rounds", || {
+        fri_prover_query_rounds::<F, C, D>(initial_merkle_trees, &trees, challenger, n, fri_params)
+    });
 
     FriProof {
         commit_phase_merkle_caps: trees.iter().map(|t| t.cap.clone()).collect(),
@@ -67,6 +84,54 @@ pub fn fri_proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const
         final_poly: final_coeffs,
         pow_witness,
     }
+}
+
+/// Builds a FRI proof synchronously (blocking).
+#[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
+pub fn fri_proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
+    initial_merkle_trees: &[&MerkleTree<F, C::Hasher>],
+    lde_polynomial_coeffs: PolynomialCoeffs<F::Extension>,
+    lde_polynomial_values: PolynomialValues<F::Extension>,
+    challenger: &mut Challenger<F, C::Hasher>,
+    fri_params: &FriParams,
+    final_poly_coeff_len: Option<usize>,
+    max_num_query_steps: Option<usize>,
+    timing: &mut TimingTree,
+) -> FriProof<F, C::Hasher, D> {
+    #[cfg(feature = "std")]
+    {
+        return block_on(fri_proof_async::<F, C, D>(
+            initial_merkle_trees,
+            lde_polynomial_coeffs,
+            lde_polynomial_values,
+            challenger,
+            fri_params,
+            final_poly_coeff_len,
+            max_num_query_steps,
+            timing,
+        ));
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        panic!("fri_proof requires the `std` feature when async proving is enabled");
+    }
+}
+
+/// `fri_proof` must not be called directly on wasm when GPU Merkle is enabled.
+#[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+pub fn fri_proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
+    _initial_merkle_trees: &[&MerkleTree<F, C::Hasher>],
+    _lde_polynomial_coeffs: PolynomialCoeffs<F::Extension>,
+    _lde_polynomial_values: PolynomialValues<F::Extension>,
+    _challenger: &mut Challenger<F, C::Hasher>,
+    _fri_params: &FriParams,
+    _final_poly_coeff_len: Option<usize>,
+    _max_num_query_steps: Option<usize>,
+    _timing: &mut TimingTree,
+) -> FriProof<F, C::Hasher, D> {
+    panic!(
+        "fri_proof must be awaited on wasm with gpu_merkle enabled; call fri_proof_async instead"
+    );
 }
 
 pub(crate) type FriCommitedTrees<F, C, const D: usize> = (
@@ -81,7 +146,11 @@ pub fn final_poly_coeff_len(mut degree_bits: usize, reduction_arity_bits: &Vec<u
     1 << degree_bits
 }
 
-fn fri_committed_trees<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
+async fn fri_committed_trees_async<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+>(
     mut coeffs: PolynomialCoeffs<F::Extension>,
     mut values: PolynomialValues<F::Extension>,
     challenger: &mut Challenger<F, C::Hasher>,
@@ -101,7 +170,9 @@ fn fri_committed_trees<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>,
             .par_chunks(arity)
             .map(|chunk: &[F::Extension]| flatten(chunk))
             .collect();
-        let tree = MerkleTree::<F, C::Hasher>::new(chunked_values, fri_params.config.cap_height);
+        let tree =
+            MerkleTree::<F, C::Hasher>::new_async(chunked_values, fri_params.config.cap_height)
+                .await;
 
         challenger.observe_cap(&tree.cap);
         trees.push(tree);
@@ -116,7 +187,7 @@ fn fri_committed_trees<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>,
                 .collect::<Vec<_>>(),
         );
         shift = shift.exp_u64(arity as u64);
-        values = coeffs.coset_fft(shift.into())
+        values = with_timer("FRI layer coset FFT", || coeffs.coset_fft(shift.into()))
     }
 
     // When verifying this proof in a circuit with a different number of query steps,

--- a/plonky2/src/fri/prover.rs
+++ b/plonky2/src/fri/prover.rs
@@ -8,7 +8,7 @@ use plonky2_field::types::Field;
     feature = "std",
     not(all(feature = "gpu_merkle", target_arch = "wasm32"))
 ))]
-use futures::executor::block_on;
+use pollster::block_on;
 use plonky2_maybe_rayon::*;
 
 use crate::field::extension::{flatten, unflatten, Extendable};

--- a/plonky2/src/fri/prover.rs
+++ b/plonky2/src/fri/prover.rs
@@ -100,7 +100,7 @@ pub fn fri_proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const
 ) -> FriProof<F, C::Hasher, D> {
     #[cfg(feature = "std")]
     {
-        return block_on(fri_proof_async::<F, C, D>(
+        block_on(fri_proof_async::<F, C, D>(
             initial_merkle_trees,
             lde_polynomial_coeffs,
             lde_polynomial_values,
@@ -109,7 +109,7 @@ pub fn fri_proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const
             final_poly_coeff_len,
             max_num_query_steps,
             timing,
-        ));
+        ))
     }
     #[cfg(not(feature = "std"))]
     {

--- a/plonky2/src/fri/prover.rs
+++ b/plonky2/src/fri/prover.rs
@@ -111,9 +111,21 @@ pub fn fri_proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const
             timing,
         ))
     }
+    // On non-wasm-gpu builds the async future is constructed from
+    // synchronous CPU code that never yields, so spinning a single-poll
+    // executor here is equivalent to running the original sync code path.
     #[cfg(not(feature = "std"))]
     {
-        panic!("fri_proof requires the `std` feature when async proving is enabled");
+        crate::util::nostd_block_on(fri_proof_async::<F, C, D>(
+            initial_merkle_trees,
+            lde_polynomial_coeffs,
+            lde_polynomial_values,
+            challenger,
+            fri_params,
+            final_poly_coeff_len,
+            max_num_query_steps,
+            timing,
+        ))
     }
 }
 

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -312,11 +312,10 @@ impl<F: RichField, H: Hasher<F>> MerkleTree<F, H> {
             let buf = mem.buffer();
             let buf_size = if let Ok(ab) = buf.dyn_into::<js_sys::ArrayBuffer>() {
                 ab.byte_length()
-            } else {
-                let sab = mem.buffer()
-                    .dyn_into::<js_sys::SharedArrayBuffer>()
-                    .unwrap();
+            } else if let Ok(sab) = mem.buffer().dyn_into::<js_sys::SharedArrayBuffer>() {
                 sab.byte_length()
+            } else {
+                0
             };
             let mem_mb = buf_size as f64 / (1024.0 * 1024.0);
             if mem_mb > 3500.0 {

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -1,11 +1,17 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+#[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+use core::mem;
 use core::mem::MaybeUninit;
 use core::slice;
 
 use plonky2_maybe_rayon::*;
 use serde::{Deserialize, Serialize};
 
+#[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+use super::merkle_tree_gpu;
+#[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+use crate::hash::hash_types::HashOut;
 use crate::hash::hash_types::RichField;
 use crate::hash::merkle_proofs::MerkleProof;
 use crate::plonk::config::{GenericHashOut, Hasher};
@@ -70,6 +76,44 @@ impl<F: RichField, H: Hasher<F>> Default for MerkleTree<F, H> {
         }
     }
 }
+
+#[cfg(feature = "merkle_debug_print")]
+fn log_merkle_tree_size(num_leaves: usize) {
+    log::info!(
+        "Constructing new Merkle tree on CPU with {} elements",
+        num_leaves
+    );
+}
+
+#[cfg(not(feature = "merkle_debug_print"))]
+fn log_merkle_tree_size(_: usize) {}
+
+#[cfg(feature = "merkle_debug_print")]
+fn log_merkle_tree_size_gpu(num_leaves: usize) {
+    log::info!(
+        "Constructing new Merkle tree on GPU with {} elements",
+        num_leaves
+    );
+}
+
+#[cfg(not(feature = "merkle_debug_print"))]
+fn log_merkle_tree_size_gpu(_: usize) {}
+
+#[cfg(feature = "merkle_debug_print")]
+fn log_merkle_tree_done() {
+    log::info!("--> construction on CPU done!");
+}
+
+#[cfg(not(feature = "merkle_debug_print"))]
+fn log_merkle_tree_done() {}
+
+#[cfg(feature = "merkle_debug_print")]
+fn log_merkle_tree_done_gpu() {
+    log::info!("--> construction on GPU done!");
+}
+
+#[cfg(not(feature = "merkle_debug_print"))]
+fn log_merkle_tree_done_gpu() {}
 
 pub(crate) fn capacity_up_to_mut<T>(v: &mut Vec<T>, len: usize) -> &mut [MaybeUninit<T>] {
     assert!(v.capacity() >= len);
@@ -190,7 +234,9 @@ pub(crate) fn merkle_tree_prove<F: RichField, H: Hasher<F>>(
 }
 
 impl<F: RichField, H: Hasher<F>> MerkleTree<F, H> {
-    pub fn new(leaves: Vec<Vec<F>>, cap_height: usize) -> Self {
+    fn build_cpu(leaves: Vec<Vec<F>>, cap_height: usize) -> Self {
+        log_merkle_tree_size(leaves.len());
+
         let log2_leaves_len = log2_strict(leaves.len());
         assert!(
             cap_height <= log2_leaves_len,
@@ -216,11 +262,105 @@ impl<F: RichField, H: Hasher<F>> MerkleTree<F, H> {
             cap.set_len(len_cap);
         }
 
+        log_merkle_tree_done();
+
         Self {
             leaves,
             digests,
             cap: MerkleCap(cap),
         }
+    }
+
+    pub fn new(leaves: Vec<Vec<F>>, cap_height: usize) -> Self {
+        Self::build_cpu(leaves, cap_height)
+    }
+
+    #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+    async fn build_gpu(leaves: Vec<Vec<F>>, cap_height: usize) -> Self {
+        log_merkle_tree_size_gpu(leaves.len());
+        let leaf_count = leaves.len();
+        //if leaf_count < 500000 {
+
+        let elems_per_leaf = leaves[0].len();
+        log::info!(
+            "{}",
+            format!(
+                "Leaf count: {}, elems per leaf: {}, cap_height: {}",
+                leaf_count, elems_per_leaf, cap_height
+            )
+        );
+
+        //if leaf_count < 8000 {
+        //if elems_per_leaf > 200 {
+        // NOTE: in `prove_singles` we do *NOT* get a deadlock if we exclude the 4096 leaf Merkle trees.
+        // We *DO* get a deadlock if we ONLY do the Merkle tree with 4096 leaves with 2431 elements per leaf.
+        // We ALSO get a deadlock in a 4096 leaf tree, if we *ONLY* exclude the tree with 2431 elements per leaf.
+        if leaf_count == 4096 {
+            return Self::build_cpu(leaves, cap_height);
+        }
+        let log2_leaves = log2_strict(leaf_count);
+        if cap_height >= log2_leaves {
+            return Self::build_cpu(leaves, cap_height);
+        }
+
+        if leaf_count < 4096 {
+            return Self::build_cpu(leaves, cap_height);
+        }
+        if let Some(result) = merkle_tree_gpu::try_build_merkle_tree::<F>(&leaves, cap_height) {
+            match result {
+                Ok(job) => match job.await_async().await {
+                    Ok(output) => {
+                        log_merkle_tree_done_gpu();
+                        return Self::from_gpu_output(leaves, output);
+                    }
+                    Err(err) => {
+                        web_sys::console::warn_1(
+                            &format!(
+                                "Merkle GPU job failed; falling back to CPU construction: {err}"
+                            )
+                            .into(),
+                        );
+                    }
+                },
+                Err(err) => {
+                    web_sys::console::warn_1(
+                        &format!("Merkle GPU path unavailable; falling back to CPU: {err}").into(),
+                    );
+                }
+            }
+        } else {
+            web_sys::console::warn_1(
+                &format!("WebGPU context not initialized. Falling back to CPU construction!")
+                    .into(),
+            );
+        }
+
+        Self::build_cpu(leaves, cap_height)
+    }
+
+    #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+    fn from_gpu_output(leaves: Vec<Vec<F>>, output: merkle_tree_gpu::GpuMerkleOutput<F>) -> Self {
+        let merkle_tree_gpu::GpuMerkleOutput { digests, cap } = output;
+        // SAFETY: HashOut<F> and H::Hash share the same layout when H::Hash = HashOut<F>.
+        let digests: Vec<H::Hash> =
+            unsafe { mem::transmute::<Vec<HashOut<F>>, Vec<H::Hash>>(digests) };
+        let cap_vec: Vec<H::Hash> = unsafe { mem::transmute::<Vec<HashOut<F>>, Vec<H::Hash>>(cap) };
+
+        Self {
+            leaves,
+            digests,
+            cap: MerkleCap(cap_vec),
+        }
+    }
+
+    #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+    pub async fn new_async(leaves: Vec<Vec<F>>, cap_height: usize) -> Self {
+        Self::build_gpu(leaves, cap_height).await
+    }
+
+    #[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
+    pub async fn new_async(leaves: Vec<Vec<F>>, cap_height: usize) -> Self {
+        Self::build_cpu(leaves, cap_height)
     }
 
     pub fn get(&self, i: usize) -> &[F] {

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -11,6 +11,8 @@ use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
 use super::merkle_tree_gpu;
 #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+use wasm_bindgen::JsCast;
+#[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
 use crate::hash::hash_types::HashOut;
 use crate::hash::hash_types::RichField;
 use crate::hash::merkle_proofs::MerkleProof;
@@ -299,6 +301,34 @@ impl<F: RichField, H: Hasher<F>> MerkleTree<F, H> {
         // and certain tree sizes (e.g. 4096 leaves) can cause GPU deadlocks.
         if leaf_count < 65536 {
             return Self::build_cpu(leaves, cap_height);
+        }
+
+        // Fall back to CPU when WASM memory is above 3.5GB to avoid OOM.
+        // The GPU path requires a staging buffer (~2x digest size) that the CPU path doesn't need.
+        {
+            let mem = wasm_bindgen::memory()
+                .dyn_into::<js_sys::WebAssembly::Memory>()
+                .unwrap();
+            let buf = mem.buffer();
+            let buf_size = if let Ok(ab) = buf.dyn_into::<js_sys::ArrayBuffer>() {
+                ab.byte_length()
+            } else {
+                let sab = mem.buffer()
+                    .dyn_into::<js_sys::SharedArrayBuffer>()
+                    .unwrap();
+                sab.byte_length()
+            };
+            let mem_mb = buf_size as f64 / (1024.0 * 1024.0);
+            if mem_mb > 3500.0 {
+                web_sys::console::warn_1(
+                    &format!(
+                        "WASM memory at {:.0}MB (>3.5GB), falling back to CPU Merkle to avoid OOM",
+                        mem_mb
+                    )
+                    .into(),
+                );
+                return Self::build_cpu(leaves, cap_height);
+            }
         }
         if let Some(result) = merkle_tree_gpu::try_build_merkle_tree::<F>(&leaves, cap_height) {
             match result {

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -290,20 +290,14 @@ impl<F: RichField, H: Hasher<F>> MerkleTree<F, H> {
             )
         );
 
-        //if leaf_count < 8000 {
-        //if elems_per_leaf > 200 {
-        // NOTE: in `prove_singles` we do *NOT* get a deadlock if we exclude the 4096 leaf Merkle trees.
-        // We *DO* get a deadlock if we ONLY do the Merkle tree with 4096 leaves with 2431 elements per leaf.
-        // We ALSO get a deadlock in a 4096 leaf tree, if we *ONLY* exclude the tree with 2431 elements per leaf.
-        if leaf_count == 4096 {
-            return Self::build_cpu(leaves, cap_height);
-        }
         let log2_leaves = log2_strict(leaf_count);
         if cap_height >= log2_leaves {
             return Self::build_cpu(leaves, cap_height);
         }
 
-        if leaf_count < 4096 {
+        // Fall back to CPU for smaller trees — GPU overhead isn't worth it,
+        // and certain tree sizes (e.g. 4096 leaves) can cause GPU deadlocks.
+        if leaf_count < 65536 {
             return Self::build_cpu(leaves, cap_height);
         }
         if let Some(result) = merkle_tree_gpu::try_build_merkle_tree::<F>(&leaves, cap_height) {

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -88,7 +88,11 @@ fn log_merkle_tree_size(num_leaves: usize) {
 #[cfg(not(feature = "merkle_debug_print"))]
 fn log_merkle_tree_size(_: usize) {}
 
-#[cfg(feature = "merkle_debug_print")]
+#[cfg(all(
+    feature = "gpu_merkle",
+    target_arch = "wasm32",
+    feature = "merkle_debug_print"
+))]
 fn log_merkle_tree_size_gpu(num_leaves: usize) {
     log::info!(
         "Constructing new Merkle tree on GPU with {} elements",
@@ -96,7 +100,11 @@ fn log_merkle_tree_size_gpu(num_leaves: usize) {
     );
 }
 
-#[cfg(not(feature = "merkle_debug_print"))]
+#[cfg(all(
+    feature = "gpu_merkle",
+    target_arch = "wasm32",
+    not(feature = "merkle_debug_print")
+))]
 fn log_merkle_tree_size_gpu(_: usize) {}
 
 #[cfg(feature = "merkle_debug_print")]
@@ -107,12 +115,20 @@ fn log_merkle_tree_done() {
 #[cfg(not(feature = "merkle_debug_print"))]
 fn log_merkle_tree_done() {}
 
-#[cfg(feature = "merkle_debug_print")]
+#[cfg(all(
+    feature = "gpu_merkle",
+    target_arch = "wasm32",
+    feature = "merkle_debug_print"
+))]
 fn log_merkle_tree_done_gpu() {
     log::info!("--> construction on GPU done!");
 }
 
-#[cfg(not(feature = "merkle_debug_print"))]
+#[cfg(all(
+    feature = "gpu_merkle",
+    target_arch = "wasm32",
+    not(feature = "merkle_debug_print")
+))]
 fn log_merkle_tree_done_gpu() {}
 
 pub(crate) fn capacity_up_to_mut<T>(v: &mut Vec<T>, len: usize) -> &mut [MaybeUninit<T>] {

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -299,7 +299,7 @@ impl<F: RichField, H: Hasher<F>> MerkleTree<F, H> {
 
         // Fall back to CPU for smaller trees — GPU overhead isn't worth it,
         // and certain tree sizes (e.g. 4096 leaves) can cause GPU deadlocks.
-        if leaf_count < 65536 {
+        if leaf_count < 8192 {
             return Self::build_cpu(leaves, cap_height);
         }
 

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -5,14 +5,14 @@ use core::slice;
 
 use plonky2_maybe_rayon::*;
 use serde::{Deserialize, Serialize};
+#[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+use wasm_bindgen::JsCast;
 
 #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
 use super::merkle_tree_gpu;
-#[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
-use wasm_bindgen::JsCast;
+use crate::hash::hash_types::RichField;
 #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
 use crate::hash::hash_types::{HashOut, NUM_HASH_OUT_ELTS};
-use crate::hash::hash_types::RichField;
 use crate::hash::merkle_proofs::MerkleProof;
 use crate::plonk::config::{GenericHashOut, Hasher};
 use crate::util::log2_strict;

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -1,7 +1,5 @@
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-#[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
-use core::mem;
 use core::mem::MaybeUninit;
 use core::slice;
 
@@ -363,11 +361,27 @@ impl<F: RichField, H: Hasher<F>> MerkleTree<F, H> {
 
     #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
     fn from_gpu_output(leaves: Vec<Vec<F>>, output: merkle_tree_gpu::GpuMerkleOutput<F>) -> Self {
+        // SECURITY: the WGSL Merkle kernels are hard-coded to Poseidon-Goldilocks
+        // and emit `HashOut<F>` digests. We convert each digest to `H::Hash`
+        // through `GenericHashOut::to_bytes`/`from_bytes`, which is the identity
+        // when `H::Hash == HashOut<F>` (the only sound configuration: e.g.
+        // `PoseidonGoldilocksConfig`). For any other hasher this round-trip
+        // produces an `H::Hash` value whose bytes do not match what `H` would
+        // have computed; the resulting Merkle root will not pass verifier
+        // checks against `H`. That is a *liveness* failure (proof rejected),
+        // not a *soundness* failure (invalid proof accepted) — which is the
+        // safety property we must preserve. This avoids the `mem::transmute`
+        // used by the upstream Lita code, whose layout assumption was UB
+        // whenever `H::Hash != HashOut<F>`.
         let merkle_tree_gpu::GpuMerkleOutput { digests, cap } = output;
-        // SAFETY: HashOut<F> and H::Hash share the same layout when H::Hash = HashOut<F>.
-        let digests: Vec<H::Hash> =
-            unsafe { mem::transmute::<Vec<HashOut<F>>, Vec<H::Hash>>(digests) };
-        let cap_vec: Vec<H::Hash> = unsafe { mem::transmute::<Vec<HashOut<F>>, Vec<H::Hash>>(cap) };
+        let digests: Vec<H::Hash> = digests
+            .into_iter()
+            .map(|h| H::Hash::from_bytes(&h.to_bytes()))
+            .collect();
+        let cap_vec: Vec<H::Hash> = cap
+            .into_iter()
+            .map(|h| H::Hash::from_bytes(&h.to_bytes()))
+            .collect();
 
         Self {
             leaves,

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -11,7 +11,7 @@ use super::merkle_tree_gpu;
 #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
 use wasm_bindgen::JsCast;
 #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
-use crate::hash::hash_types::HashOut;
+use crate::hash::hash_types::{HashOut, NUM_HASH_OUT_ELTS};
 use crate::hash::hash_types::RichField;
 use crate::hash::merkle_proofs::MerkleProof;
 use crate::plonk::config::{GenericHashOut, Hasher};
@@ -301,6 +301,17 @@ impl<F: RichField, H: Hasher<F>> MerkleTree<F, H> {
             return Self::build_cpu(leaves, cap_height);
         }
 
+        // SECURITY (Attacker C1): the WGSL leaf-hash kernel always applies
+        // the Poseidon permutation, but the CPU `Hasher::hash_or_noop` skips
+        // the permutation when `inputs.len() * 8 <= H::HASH_SIZE` (returning
+        // the zero-padded canonical bytes directly). For short leaves the GPU
+        // and CPU paths therefore disagree on the leaf digest, producing
+        // mismatched Merkle roots. Fall back to CPU whenever a leaf is short
+        // enough to trigger the no-op branch on the verifier side.
+        if elems_per_leaf * core::mem::size_of::<F>() <= H::HASH_SIZE {
+            return Self::build_cpu(leaves, cap_height);
+        }
+
         // Fall back to CPU when WASM memory is above 3.5GB to avoid OOM.
         // The GPU path requires a staging buffer (~2x digest size) that the CPU path doesn't need.
         {
@@ -361,18 +372,31 @@ impl<F: RichField, H: Hasher<F>> MerkleTree<F, H> {
 
     #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
     fn from_gpu_output(leaves: Vec<Vec<F>>, output: merkle_tree_gpu::GpuMerkleOutput<F>) -> Self {
-        // SECURITY: the WGSL Merkle kernels are hard-coded to Poseidon-Goldilocks
-        // and emit `HashOut<F>` digests. We convert each digest to `H::Hash`
-        // through `GenericHashOut::to_bytes`/`from_bytes`, which is the identity
-        // when `H::Hash == HashOut<F>` (the only sound configuration: e.g.
-        // `PoseidonGoldilocksConfig`). For any other hasher this round-trip
-        // produces an `H::Hash` value whose bytes do not match what `H` would
-        // have computed; the resulting Merkle root will not pass verifier
-        // checks against `H`. That is a *liveness* failure (proof rejected),
-        // not a *soundness* failure (invalid proof accepted) — which is the
-        // safety property we must preserve. This avoids the `mem::transmute`
-        // used by the upstream Lita code, whose layout assumption was UB
-        // whenever `H::Hash != HashOut<F>`.
+        // SECURITY (Attacker C2 / M-1): the WGSL Merkle kernels are hard-coded
+        // to Poseidon-Goldilocks and emit `HashOut<F>` digests (32 bytes:
+        // `NUM_HASH_OUT_ELTS * size_of::<F>()`). The bytes round-trip below
+        // is sound *only* when `H::HASH_SIZE` matches that footprint:
+        //   - If `H::HASH_SIZE > 32`, `H::Hash::from_bytes` would read out
+        //     of bounds.
+        //   - If `H::HASH_SIZE < 32`, bytes would be silently truncated.
+        // Reject unsupported hashers loudly here. The check is a single
+        // const-evaluable comparison per call (constant-folded in release).
+        let expected_hash_bytes = NUM_HASH_OUT_ELTS * core::mem::size_of::<F>();
+        assert_eq!(
+            H::HASH_SIZE,
+            expected_hash_bytes,
+            "GPU Merkle output is only valid when H::HASH_SIZE matches HashOut<F>; \
+             refusing to convert digests for an incompatible hasher"
+        );
+
+        // For `H::Hash == HashOut<F>` (e.g. `PoseidonGoldilocksConfig`) the
+        // round-trip is byte-for-byte identity. For any other hasher with the
+        // same `HASH_SIZE` (e.g. `KeccakHash<32>`) the resulting digests will
+        // not match what `H` itself would have computed, so the verifier
+        // rejects the proof — a liveness failure, not a soundness failure
+        // (which is the safety property we must preserve). This avoids the
+        // `mem::transmute` used by upstream Lita, whose layout assumption was
+        // UB whenever `H::Hash != HashOut<F>`.
         let merkle_tree_gpu::GpuMerkleOutput { digests, cap } = output;
         let digests: Vec<H::Hash> = digests
             .into_iter()

--- a/plonky2/src/hash/merkle_tree_gpu.rs
+++ b/plonky2/src/hash/merkle_tree_gpu.rs
@@ -1,0 +1,2007 @@
+//! WebGPU scaffolding for Merkle tree construction.
+//!
+//! This module mirrors the CPU Merkle construction in `merkle_tree.rs` but offloads the heavy
+//! Poseidon hashing to a WGSL compute shader. The shader expects Goldilocks field elements in
+//! Montgomery form (`a * R mod p` with `R = 2^64`). We therefore convert all hash inputs and
+//! constants to Montgomery before uploading them to the GPU and convert results back to the
+//! canonical representation after read-back.
+
+#![cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+
+use std::cell::RefCell;
+use std::marker::PhantomData;
+use std::num::NonZeroU64;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use anyhow::{anyhow, ensure, Result};
+use bytemuck::{Pod, Zeroable};
+use futures::channel::oneshot;
+use once_cell::unsync::OnceCell;
+use web_sys::console;
+use wgpu::util::DeviceExt;
+use wgpu::{BindGroupLayout, Buffer, ComputePipeline, Device, Queue, SubmissionIndex};
+
+use crate::hash::hash_types::{HashOut, RichField, NUM_HASH_OUT_ELTS};
+use crate::hash::poseidon::{self, Poseidon, SPONGE_WIDTH};
+// Goldilocks modulus and Montgomery parameters.
+const GOLDILOCKS_MODULUS: u64 = 0xFFFF_FFFF_0000_0001;
+const MONTGOMERY_R: u128 = 1u128 << 64;
+
+const BIGINT_LIMBS: usize = 2;
+const DIGEST_ELEMENTS: usize = NUM_HASH_OUT_ELTS;
+const WORDS_PER_DIGEST: usize = DIGEST_ELEMENTS * BIGINT_LIMBS;
+const BYTES_PER_DIGEST: usize = WORDS_PER_DIGEST * std::mem::size_of::<u32>();
+const BYTES_PER_BIGINT: usize = BIGINT_LIMBS * std::mem::size_of::<u32>();
+const POSEIDON_WIDTH: usize = SPONGE_WIDTH;
+const ROUND_CONSTANT_COUNT: usize = POSEIDON_WIDTH * poseidon::N_ROUNDS;
+
+// for `now` for timing
+use js_sys::Promise;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::JsFuture;
+
+thread_local! {
+    /// WebGPU context reused across Merkle tree constructions.
+    static GPU_CONTEXT: OnceCell<Rc<MerkleTreeGpuContext>> = OnceCell::new();
+}
+
+/// Cached pipeline and device handles required to launch the Merkle compute kernel.
+#[derive(Debug)]
+pub struct MerkleTreeGpuContext {
+    pub device: Rc<Device>,
+    pub queue: Rc<Queue>,
+    pub merkle_pipeline: Rc<ComputePipeline>,
+    pub merkle_bind_group_layout: Rc<BindGroupLayout>,
+    pub leaf_pipeline: Rc<ComputePipeline>,
+    pub leaf_bind_group_layout: Rc<BindGroupLayout>,
+    pub transpose_to_mont_pipeline: Rc<ComputePipeline>,
+    pub transpose_to_mont_bind_group_layout: Rc<BindGroupLayout>,
+
+    pub to_canon_pipeline: Rc<ComputePipeline>,
+    pub to_canon_bind_group_layout: Rc<BindGroupLayout>,
+
+    pub mds_circ: Buffer,
+    pub mds_diag: Buffer,
+    pub round_constants: Buffer,
+
+    // Cached staging buffer for readbacks (web: reused to avoid churn)
+    pub readback_staging: RefCell<Option<Buffer>>,
+    pub readback_capacity: RefCell<u64>,
+}
+
+impl MerkleTreeGpuContext {
+    fn new(
+        device: Device,
+        queue: Queue,
+        merkle_pipeline: ComputePipeline,
+        merkle_bind_group_layout: BindGroupLayout,
+        leaf_pipeline: ComputePipeline,
+        leaf_bind_group_layout: BindGroupLayout,
+        transpose_to_mont_pipeline: ComputePipeline,
+        transpose_to_mont_bind_group_layout: BindGroupLayout,
+
+        to_canon_pipeline: ComputePipeline,
+        to_canon_bind_group_layout: BindGroupLayout,
+
+        mds_circ: Buffer,
+        mds_diag: Buffer,
+        round_constants: Buffer,
+    ) -> Self {
+        let device = Rc::new(device);
+        device.on_uncaptured_error(Box::new(|error| {
+            #[cfg(target_arch = "wasm32")]
+            {
+                web_sys::console::error_1(
+                    &format!("⚠️ WebGPU uncaptured error in Merkle context: {error:?}").into(),
+                );
+            }
+        }));
+
+        Self {
+            device,
+            queue: Rc::new(queue),
+            merkle_pipeline: Rc::new(merkle_pipeline),
+            merkle_bind_group_layout: Rc::new(merkle_bind_group_layout),
+            leaf_pipeline: Rc::new(leaf_pipeline),
+            leaf_bind_group_layout: Rc::new(leaf_bind_group_layout),
+            transpose_to_mont_pipeline: Rc::new(transpose_to_mont_pipeline),
+            transpose_to_mont_bind_group_layout: Rc::new(transpose_to_mont_bind_group_layout),
+            to_canon_pipeline: Rc::new(to_canon_pipeline),
+            to_canon_bind_group_layout: Rc::new(to_canon_bind_group_layout),
+            readback_staging: RefCell::new(None),
+            readback_capacity: RefCell::new(0),
+            mds_circ,
+            mds_diag,
+            round_constants,
+        }
+    }
+}
+
+impl MerkleTreeGpuContext {
+    fn get_or_make_staging(&self, size: u64) -> Buffer {
+        let mut cap = self.readback_capacity.borrow_mut();
+        let mut buf_opt = self.readback_staging.borrow_mut();
+        let need_new = buf_opt.is_none() || *cap < size;
+        if need_new {
+            let new_buf = self.device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("merkle-readback-staging"),
+                size,
+                usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+                mapped_at_creation: false,
+            });
+            *buf_opt = Some(new_buf);
+            *cap = size;
+        }
+        buf_opt.as_ref().unwrap().clone()
+    }
+}
+
+/// Parameters handed to the Merkle tree kernel for a single layer dispatch.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod, Zeroable)]
+struct MerkleTreeKernelArgs {
+    cap_len: u32,
+    layer: u32,
+    src_layer_size: u32,
+    dst_layer_size: u32,
+    src_offset: u32,
+    dst_offset: u32,
+    write_to_cap: u32,
+}
+
+/// Montgomery helper: convert canonical Goldilocks element (as `u64`) into Montgomery form.
+fn to_montgomery_u64(value: u64) -> u64 {
+    let res = ((value as u128) * MONTGOMERY_R) % (GOLDILOCKS_MODULUS as u128);
+    res as u64
+}
+
+fn field_to_montgomery_words<F: RichField>(value: &F) -> [u32; BIGINT_LIMBS] {
+    let canonical = value.to_canonical_u64();
+    let monty = to_montgomery_u64(canonical);
+    [(monty & 0xFFFF_FFFF) as u32, (monty >> 32) as u32]
+}
+
+fn field_to_words<F: RichField>(value: &F) -> [u32; BIGINT_LIMBS] {
+    let canon = value.to_canonical_u64();
+    [(canon & 0xFFFF_FFFF) as u32, (canon >> 32) as u32]
+}
+
+fn words_to_field<F: RichField>(words: &[u32; BIGINT_LIMBS]) -> F {
+    let canon = (words[1] as u64) << 32 | (words[0] as u64);
+    F::from_canonical_u64(canon)
+}
+
+fn words_to_hash<F: RichField>(words: &[u32]) -> Result<HashOut<F>> {
+    ensure!(
+        words.len() == WORDS_PER_DIGEST,
+        "expected {} words per digest, got {}",
+        WORDS_PER_DIGEST,
+        words.len()
+    );
+    let mut elements = [F::ZERO; NUM_HASH_OUT_ELTS];
+    for (i, chunk) in words.chunks(BIGINT_LIMBS).enumerate() {
+        let chunk: [u32; BIGINT_LIMBS] = chunk.try_into().unwrap();
+        elements[i] = words_to_field(&chunk);
+    }
+    Ok(HashOut { elements })
+}
+
+fn log(msg: &str) {
+    #[cfg(not(feature = "gpu_merkle_logging"))]
+    let _ = msg;
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        #[cfg(feature = "gpu_merkle_logging")]
+        web_sys::console::log_1(&msg.into());
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        println!("{msg}");
+    }
+}
+
+fn log_lazy<F>(builder: F)
+where
+    F: FnOnce() -> String,
+{
+    #[cfg(feature = "gpu_merkle_logging")]
+    {
+        log(&builder());
+    }
+
+    #[cfg(not(feature = "gpu_merkle_logging"))]
+    {
+        let _ = builder;
+    }
+}
+
+fn log_queue_submission(label: &str, index: SubmissionIndex) {
+    log_lazy(|| format!("📤 Queue submit -> {label} (submission_index={index:?})"));
+}
+
+/// Monotonic identifier used to correlate instrumentation logs.
+static READBACK_SEQ: AtomicU32 = AtomicU32::new(1);
+
+// ============================================================================
+// PROFILING HELPERS
+// ============================================================================
+
+/// We need to use the `performance` feature of WASM for profiling. Otherwise when
+/// running in a web worker
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = performance)]
+    fn now() -> f64;
+}
+
+/// Get high-resolution timestamp in milliseconds
+fn now_ms() -> f64 {
+    #[cfg(target_arch = "wasm32")]
+    {
+        //web_sys::window().unwrap().performance().unwrap().now()
+        now()
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        // For native, use a simple placeholder
+        0.0
+    }
+}
+
+/// Log timing information to console
+fn log_timing(label: &str, duration_ms: f64) {
+    #[cfg(target_arch = "wasm32")]
+    {
+        console::log_1(&format!("⏱️  {}: {:.2}ms", label, duration_ms).into());
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        println!("⏱️  {}: {:.2}ms", label, duration_ms);
+    }
+}
+
+/// Log timing information to console
+fn log_timing_verbose(label: &str, duration_ms: f64) {
+    #[cfg(not(feature = "gpu_merkle_verbose_time_logging"))]
+    {
+        let _ = label;
+        let _ = duration_ms;
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        #[cfg(feature = "gpu_merkle_verbose_time_logging")]
+        console::log_1(&format!("⏱️  {}: {:.2}ms", label, duration_ms).into());
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        println!("⏱️  {}: {:.2}ms", label, duration_ms);
+    }
+}
+
+/// Yield back to the JS event loop to give pending GPU callbacks a chance to fire.
+async fn yield_to_event_loop() {
+    let promise = Promise::resolve(&JsValue::NULL);
+    let _ = JsFuture::from(promise).await;
+}
+
+/// Helper that pops a previously-pushed error scope.
+async fn pop_error_scope(device: Rc<Device>, label: String) -> Option<wgpu::Error> {
+    let result = device.pop_error_scope().await;
+    if let Some(ref err) = result {
+        log_lazy(|| format!("{label} -> error: {err:?}"));
+    } else {
+        log_lazy(|| format!("{label} -> no error"));
+    }
+    result
+}
+
+/// Initialize the global WebGPU context. Subsequent calls are no-ops.
+pub async fn initialize() -> Result<()> {
+    if GPU_CONTEXT.with(|cell| cell.get().is_some()) {
+        return Ok(());
+    }
+
+    log("Initializing GPU context");
+
+    let inst_desc = wgpu::InstanceDescriptor {
+        backends: wgpu::Backends::BROWSER_WEBGPU,
+        ..Default::default()
+    };
+    let instance = wgpu::Instance::new(&inst_desc);
+
+    log("Requesting adapter");
+
+    let adapter = instance
+        .request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            compatible_surface: None,
+            force_fallback_adapter: false,
+        })
+        .await
+        .expect("failed to obtain WebGPU adapter");
+    //.ok_or_else(|| anyhow!("failed to obtain WebGPU adapter"))?;
+
+    log("Requesting device");
+
+    let mut limits = wgpu::Limits::default();
+    //limits.max_buffer_size = (1 << 32) - 5;
+    //limits.max_storage_buffer_binding_size = (1 << 32) - 5;
+    limits.max_buffer_size = 1073741824;
+    limits.max_storage_buffer_binding_size = 1073741824;
+
+    let (device, queue) = adapter
+        .request_device(
+            &wgpu::DeviceDescriptor {
+                label: Some("Merkle Tree Device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: limits,
+                memory_hints: wgpu::MemoryHints::MemoryUsage,
+                trace: wgpu::Trace::Off,
+            },
+            //None,
+        )
+        .await
+        .map_err(|err| anyhow!("failed to create WebGPU device: {err}"))?;
+
+    log("Creating bind group layouts");
+
+    let merkle_bind_group_layout = create_merkle_bind_group_layout(&device);
+    let merkle_pipeline = create_merkle_pipeline(&device, &merkle_bind_group_layout)?;
+    let leaf_bind_group_layout = create_leaf_hash_bind_group_layout(&device);
+    let leaf_pipeline = create_leaf_hash_pipeline(&device, &leaf_bind_group_layout)?;
+    let transpose_to_mont_bind_group_layout = create_transpose_to_mont_bind_group_layout(&device);
+    let transpose_to_mont_pipeline =
+        create_transpose_to_mont_pipeline(&device, &transpose_to_mont_bind_group_layout)?;
+    let to_canon_bind_group_layout = create_to_canon_bind_group_layout(&device);
+    let to_canon_pipeline = create_to_canon_pipeline(&device, &to_canon_bind_group_layout)?;
+
+    let (mds_circ, mds_diag, round_constants) = create_poseidon_constant_buffers::<
+        crate::field::goldilocks_field::GoldilocksField,
+    >(&device);
+
+    log("Creating Merkle GPU context");
+
+    let context = Rc::new(MerkleTreeGpuContext::new(
+        device,
+        queue,
+        merkle_pipeline,
+        merkle_bind_group_layout,
+        leaf_pipeline,
+        leaf_bind_group_layout,
+        transpose_to_mont_pipeline,
+        transpose_to_mont_bind_group_layout,
+        to_canon_pipeline,
+        to_canon_bind_group_layout,
+        mds_circ,
+        mds_diag,
+        round_constants,
+    ));
+
+    log("Setting RC cell content");
+
+    GPU_CONTEXT.with(|cell| {
+        cell.set(context)
+            .map_err(|_| anyhow!("GPU context already initialized"))
+    })?;
+
+    console::info_1(&"Merkle GPU context initialized".into());
+    Ok(())
+}
+
+fn create_merkle_pipeline(
+    device: &Device,
+    bind_group_layout: &BindGroupLayout,
+) -> Result<ComputePipeline> {
+    let shader_module =
+        device.create_shader_module(wgpu::include_wgsl!("../../shaders/merkle_tree.wgsl"));
+
+    log("creating Merkle tree compute pipeline");
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("Merkle Tree Pipeline Layout"),
+        bind_group_layouts: &[bind_group_layout],
+        push_constant_ranges: &[],
+    });
+
+    Ok(
+        device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("Merkle Tree Pipeline"),
+            layout: Some(&pipeline_layout),
+            module: &shader_module,
+            entry_point: Some("processMerkleTreeLayerWithCap"),
+            compilation_options: Default::default(),
+            cache: None,
+        }),
+    )
+}
+
+fn create_leaf_hash_pipeline(
+    device: &Device,
+    bind_group_layout: &BindGroupLayout,
+) -> Result<ComputePipeline> {
+    let shader_module =
+        device.create_shader_module(wgpu::include_wgsl!("../../shaders/poseidon1_hash.wgsl"));
+
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("Poseidon Leaf Hash Pipeline Layout"),
+        bind_group_layouts: &[bind_group_layout],
+        push_constant_ranges: &[],
+    });
+
+    Ok(
+        device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("Poseidon Leaf Hash Pipeline"),
+            layout: Some(&pipeline_layout),
+            module: &shader_module,
+            entry_point: Some("poseidon1Hash"),
+            compilation_options: Default::default(),
+            cache: None,
+        }),
+    )
+}
+
+fn create_transpose_to_mont_pipeline(
+    device: &Device,
+    bind_group_layout: &BindGroupLayout,
+) -> Result<ComputePipeline> {
+    let shader_module = device.create_shader_module(wgpu::include_wgsl!(
+        "../../shaders/transpose_to_montgomery.wgsl"
+    ));
+
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("Buffer Transpose to Montgomery Pipeline Layout"),
+        bind_group_layouts: &[bind_group_layout],
+        push_constant_ranges: &[],
+    });
+
+    Ok(
+        device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("Buffer Transpose to Montgomery Pipeline"),
+            layout: Some(&pipeline_layout),
+            module: &shader_module,
+            entry_point: Some("transposeNaive"),
+            compilation_options: Default::default(),
+            cache: None,
+        }),
+    )
+}
+
+fn create_to_canon_pipeline(
+    device: &Device,
+    bind_group_layout: &BindGroupLayout,
+) -> Result<ComputePipeline> {
+    let shader_module = device.create_shader_module(wgpu::include_wgsl!(
+        "../../shaders/buffer_montgomery_to_canonical.wgsl"
+    ));
+
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("Buffer Montgomery to Canonical Pipeline Layout"),
+        bind_group_layouts: &[bind_group_layout],
+        push_constant_ranges: &[],
+    });
+
+    Ok(
+        device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("Buffer Montgomery to Canonical Pipeline"),
+            layout: Some(&pipeline_layout),
+            module: &shader_module,
+            entry_point: Some("bufferToCanonical"),
+            compilation_options: Default::default(),
+            cache: None,
+        }),
+    )
+}
+
+/// Returns `true` when the WebGPU context is ready for use.
+pub fn is_initialized() -> bool {
+    GPU_CONTEXT.with(|cell| cell.get().is_some())
+}
+
+fn create_merkle_bind_group_layout(device: &Device) -> BindGroupLayout {
+    device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("Merkle Tree Bind Group Layout"),
+        entries: &[
+            // 0: input hashed leaves
+            wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+            // 1: nodes buffer
+            wgpu::BindGroupLayoutEntry {
+                binding: 1,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+            // 2: cap buffer
+            wgpu::BindGroupLayoutEntry {
+                binding: 2,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+            // 3: per-layer uniforms
+            wgpu::BindGroupLayoutEntry {
+                binding: 3,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: true },
+                    has_dynamic_offset: false,
+                    min_binding_size: NonZeroU64::new(
+                        std::mem::size_of::<MerkleTreeKernelArgs>() as u64
+                    ),
+                },
+                count: None,
+            },
+            // 4: Poseidon MDS circulant
+            wgpu::BindGroupLayoutEntry {
+                binding: 4,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: true },
+                    has_dynamic_offset: false,
+                    min_binding_size: NonZeroU64::new(
+                        (POSEIDON_WIDTH * BIGINT_LIMBS * std::mem::size_of::<u32>()) as u64,
+                    ),
+                },
+                count: None,
+            },
+            // 5: Poseidon MDS diagonal
+            wgpu::BindGroupLayoutEntry {
+                binding: 5,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: true },
+                    has_dynamic_offset: false,
+                    min_binding_size: NonZeroU64::new(
+                        (POSEIDON_WIDTH * BIGINT_LIMBS * std::mem::size_of::<u32>()) as u64,
+                    ),
+                },
+                count: None,
+            },
+            // 6: round constants
+            wgpu::BindGroupLayoutEntry {
+                binding: 6,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: true },
+                    has_dynamic_offset: false,
+                    min_binding_size: NonZeroU64::new(
+                        (ROUND_CONSTANT_COUNT * BIGINT_LIMBS * std::mem::size_of::<u32>()) as u64,
+                    ),
+                },
+                count: None,
+            },
+        ],
+    })
+}
+
+fn create_leaf_hash_bind_group_layout(device: &Device) -> BindGroupLayout {
+    device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("Poseidon Leaf Hash Bind Group Layout"),
+        entries: &[
+            // 0: output digests
+            wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: NonZeroU64::new(BYTES_PER_DIGEST as u64),
+                },
+                count: None,
+            },
+            // 1: transposed input elements
+            wgpu::BindGroupLayoutEntry {
+                binding: 1,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+            // 2: number of leaves
+            wgpu::BindGroupLayoutEntry {
+                binding: 2,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: true },
+                    has_dynamic_offset: false,
+                    min_binding_size: NonZeroU64::new(std::mem::size_of::<i32>() as u64),
+                },
+                count: None,
+            },
+            // 3: elements per leaf
+            wgpu::BindGroupLayoutEntry {
+                binding: 3,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: true },
+                    has_dynamic_offset: false,
+                    min_binding_size: NonZeroU64::new(std::mem::size_of::<i32>() as u64),
+                },
+                count: None,
+            },
+            // 4: Poseidon MDS circulant
+            wgpu::BindGroupLayoutEntry {
+                binding: 4,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: true },
+                    has_dynamic_offset: false,
+                    min_binding_size: NonZeroU64::new(
+                        (POSEIDON_WIDTH * BIGINT_LIMBS * std::mem::size_of::<u32>()) as u64,
+                    ),
+                },
+                count: None,
+            },
+            // 5: Poseidon MDS diagonal
+            wgpu::BindGroupLayoutEntry {
+                binding: 5,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: true },
+                    has_dynamic_offset: false,
+                    min_binding_size: NonZeroU64::new(
+                        (POSEIDON_WIDTH * BIGINT_LIMBS * std::mem::size_of::<u32>()) as u64,
+                    ),
+                },
+                count: None,
+            },
+            // 6: round constants
+            wgpu::BindGroupLayoutEntry {
+                binding: 6,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: true },
+                    has_dynamic_offset: false,
+                    min_binding_size: NonZeroU64::new(
+                        (ROUND_CONSTANT_COUNT * BIGINT_LIMBS * std::mem::size_of::<u32>()) as u64,
+                    ),
+                },
+                count: None,
+            },
+        ],
+    })
+}
+
+fn create_transpose_to_mont_bind_group_layout(device: &Device) -> BindGroupLayout {
+    device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("Buffer Transpose to Montgomery Bind Group Layout"),
+        entries: &[
+            // 0: output buffer
+            wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: NonZeroU64::new(BYTES_PER_BIGINT as u64),
+                },
+                count: None,
+            },
+            // 1: input buffer to transpose & convert
+            wgpu::BindGroupLayoutEntry {
+                binding: 1,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: NonZeroU64::new(BYTES_PER_BIGINT as u64),
+                },
+                count: None,
+            },
+            // 2: number of leaves
+            wgpu::BindGroupLayoutEntry {
+                binding: 2,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: true },
+                    has_dynamic_offset: false,
+                    min_binding_size: NonZeroU64::new(std::mem::size_of::<u32>() as u64),
+                },
+                count: None,
+            },
+            // 2: elements per leaf
+            wgpu::BindGroupLayoutEntry {
+                binding: 3,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: true },
+                    has_dynamic_offset: false,
+                    min_binding_size: NonZeroU64::new(std::mem::size_of::<u32>() as u64),
+                },
+                count: None,
+            },
+        ],
+    })
+}
+
+fn create_to_canon_bind_group_layout(device: &Device) -> BindGroupLayout {
+    device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("Buffer Montgomery to Canonical Bind Group Layout"),
+        entries: &[
+            // 0: input & output buffer to convert
+            wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: NonZeroU64::new(BYTES_PER_BIGINT as u64),
+                },
+                count: None,
+            },
+            // 1: number of elements in the buffer
+            wgpu::BindGroupLayoutEntry {
+                binding: 1,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: true },
+                    has_dynamic_offset: false,
+                    min_binding_size: NonZeroU64::new(std::mem::size_of::<i32>() as u64),
+                },
+                count: None,
+            },
+        ],
+    })
+}
+
+fn create_poseidon_constant_buffers<F: RichField + Poseidon>(
+    device: &Device,
+) -> (Buffer, Buffer, Buffer) {
+    let mut mds_circ_words = Vec::with_capacity(POSEIDON_WIDTH * BIGINT_LIMBS);
+    for &value in F::MDS_MATRIX_CIRC.iter().take(POSEIDON_WIDTH) {
+        let field = F::from_canonical_u64(value);
+        mds_circ_words.extend_from_slice(&field_to_montgomery_words(&field));
+    }
+
+    let mut mds_diag_words = Vec::with_capacity(POSEIDON_WIDTH * BIGINT_LIMBS);
+    for &value in F::MDS_MATRIX_DIAG.iter().take(POSEIDON_WIDTH) {
+        let field = F::from_canonical_u64(value);
+        mds_diag_words.extend_from_slice(&field_to_montgomery_words(&field));
+    }
+
+    let mut rc_words = Vec::with_capacity(ROUND_CONSTANT_COUNT * BIGINT_LIMBS);
+    for &value in poseidon::ALL_ROUND_CONSTANTS
+        .iter()
+        .take(ROUND_CONSTANT_COUNT)
+    {
+        let field = F::from_canonical_u64(value);
+        rc_words.extend_from_slice(&field_to_montgomery_words(&field));
+    }
+
+    let mds_circ = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("Poseidon MDS (circ)"),
+        contents: bytemuck::cast_slice(&mds_circ_words),
+        usage: wgpu::BufferUsages::STORAGE,
+    });
+
+    let mds_diag = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("Poseidon MDS (diag)"),
+        contents: bytemuck::cast_slice(&mds_diag_words),
+        usage: wgpu::BufferUsages::STORAGE,
+    });
+
+    let round_constants = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("Poseidon round constants"),
+        contents: bytemuck::cast_slice(&rc_words),
+        usage: wgpu::BufferUsages::STORAGE,
+    });
+
+    (mds_circ, mds_diag, round_constants)
+}
+
+fn host_layer_size(input_size: usize, layer: usize) -> usize {
+    if layer == 0 {
+        return input_size;
+    }
+    let mut size = input_size / 2;
+    for _ in 1..layer {
+        size = (size + 1) / 2;
+    }
+    size
+}
+
+fn host_layer_offset(input_size: usize, layer: usize) -> usize {
+    let mut offset = 0;
+    let mut size = input_size / 2;
+    for _ in 1..layer {
+        offset += size;
+        size = (size + 1) / 2;
+    }
+    offset
+}
+
+#[derive(Debug)]
+struct MerkleBuffers {
+    input: Buffer,
+    nodes: Buffer,
+    cap: Buffer,
+}
+
+#[derive(Debug)]
+struct QueueCompletion {
+    receiver: oneshot::Receiver<()>,
+}
+
+impl QueueCompletion {
+    fn new(queue: Rc<Queue>) -> Self {
+        let (sender, receiver) = oneshot::channel();
+        queue.on_submitted_work_done(move || {
+            log("wait_for_queue -> on_submitted_work_done invoked");
+            let _ = sender.send(());
+        });
+        Self { receiver }
+    }
+
+    async fn wait(self) -> Result<()> {
+        self.receiver
+            .await
+            .map_err(|_| anyhow!("queue completion receiver dropped"))
+    }
+}
+
+#[derive(Debug)]
+enum MerkleGpuJobState {
+    Deferred {
+        context: Rc<MerkleTreeGpuContext>,
+        buffers: MerkleBuffers,
+        total_nodes: usize,
+        cap_len: usize,
+        num_leaves: usize,
+        cap_height: usize,
+        num_layers_to_cap: usize,
+        queue_completion: Option<QueueCompletion>,
+    },
+}
+
+#[derive(Debug)]
+pub struct MerkleGpuJob<F: RichField> {
+    state: MerkleGpuJobState,
+    _marker: PhantomData<F>,
+}
+
+impl<F> MerkleGpuJob<F>
+where
+    F: RichField + Poseidon + 'static,
+{
+    fn deferred(
+        context: Rc<MerkleTreeGpuContext>,
+        buffers: MerkleBuffers,
+        total_nodes: usize,
+        cap_len: usize,
+        num_leaves: usize,
+        cap_height: usize,
+        num_layers_to_cap: usize,
+        queue_completion: Option<QueueCompletion>,
+    ) -> Self {
+        Self {
+            state: MerkleGpuJobState::Deferred {
+                context,
+                buffers,
+                total_nodes,
+                cap_len,
+                num_leaves,
+                cap_height,
+                num_layers_to_cap,
+                queue_completion,
+            },
+            _marker: PhantomData,
+        }
+    }
+
+    async fn finish(self) -> Result<GpuMerkleOutput<F>> {
+        match self.state {
+            MerkleGpuJobState::Deferred {
+                context,
+                buffers,
+                total_nodes,
+                cap_len,
+                num_leaves,
+                cap_height,
+                num_layers_to_cap,
+                queue_completion,
+            } => {
+                log("=== PHASE 4: GPU Completion & Readback ===");
+                log(if queue_completion.is_some() {
+                    "wait_for_queue will await queued completion callback"
+                } else {
+                    "wait_for_queue has no completion callback recorded"
+                });
+                let readback_start = now_ms();
+
+                // Wait for GPU to finish
+                let wait_start = now_ms();
+                wait_for_queue(queue_completion).await?;
+                log_timing("⚡ GPU execution (wait_for_queue)", now_ms() - wait_start);
+
+                let mut sections = Vec::with_capacity(3);
+                sections.push(HashSection {
+                    label: "Leaf",
+                    buffer: &buffers.input,
+                    word_len: num_leaves * WORDS_PER_DIGEST,
+                });
+                if total_nodes > 0 {
+                    sections.push(HashSection {
+                        label: "Node",
+                        buffer: &buffers.nodes,
+                        word_len: total_nodes * WORDS_PER_DIGEST,
+                    });
+                }
+                sections.push(HashSection {
+                    label: "Cap",
+                    buffer: &buffers.cap,
+                    word_len: cap_len * WORDS_PER_DIGEST,
+                });
+                let section_results = read_hash_sections::<F>(&context, &sections).await?;
+                debug_assert_eq!(section_results.len(), sections.len());
+                let mut section_iter = section_results.into_iter();
+
+                let leaf_result = section_iter
+                    .next()
+                    .expect("leaf section missing from combined readback");
+                log_timing_verbose("Leaf hash readback", leaf_result.readback_ms);
+                log_timing_verbose("Leaf canonical decode", leaf_result.convert_ms);
+                let leaf_hashes = leaf_result.hashes;
+
+                let (node_hashes, cap_result) = if total_nodes > 0 {
+                    let node_result = section_iter
+                        .next()
+                        .expect("node section missing from combined readback");
+                    log_timing_verbose("Node hash readback", node_result.readback_ms);
+                    log_timing_verbose("Node canonical decode", node_result.convert_ms);
+                    let cap_result = section_iter
+                        .next()
+                        .expect("cap section missing from combined readback");
+                    (node_result.hashes, cap_result)
+                } else {
+                    let cap_result = section_iter
+                        .next()
+                        .expect("cap section missing from combined readback");
+                    (Vec::new(), cap_result)
+                };
+                debug_assert!(section_iter.next().is_none());
+                log_timing_verbose("Cap readback", cap_result.readback_ms);
+                log_timing_verbose("Cap canonical decode", cap_result.convert_ms);
+                let cap_hashes = cap_result.hashes;
+
+                // CPU post-processing: reconstruct digest tree
+                log("=== PHASE 5: CPU Post-processing ===");
+                let postprocess_start = now_ms();
+
+                let num_digests = 2 * (num_leaves - (1 << cap_height));
+                let digests = if num_digests > 0 {
+                    let mut digests = vec![HashOut::<F>::ZERO; num_digests];
+                    let accessor = LayerAccessor::new(
+                        &leaf_hashes,
+                        &node_hashes,
+                        &cap_hashes,
+                        num_leaves,
+                        num_layers_to_cap,
+                    );
+                    let subtree_digests_len = num_digests >> cap_height;
+                    let subtree_leaves_len = num_leaves >> cap_height;
+
+                    log("Subtree business");
+                    for (subtree_idx, subtree_buf) in
+                        digests.chunks_mut(subtree_digests_len).enumerate()
+                    {
+                        let leaf_offset = subtree_idx * subtree_leaves_len;
+                        write_subtree_chunk_from_gpu(
+                            subtree_buf,
+                            &accessor,
+                            leaf_offset,
+                            subtree_leaves_len,
+                        );
+                        debug_assert_eq!(
+                            accessor.node(accessor.cap_layer(), subtree_idx),
+                            &cap_hashes[subtree_idx]
+                        );
+                    }
+
+                    digests
+                } else {
+                    Vec::new()
+                };
+
+                log_timing_verbose("Digest tree reconstruction", now_ms() - postprocess_start);
+
+                log_timing_verbose(
+                    "📥 TOTAL READBACK + POST-PROCESSING",
+                    now_ms() - readback_start,
+                );
+
+                Ok(GpuMerkleOutput {
+                    digests,
+                    cap: cap_hashes,
+                })
+            }
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub async fn await_async(self) -> Result<GpuMerkleOutput<F>> {
+        let start = now_ms();
+        let result = self.finish().await;
+        log_timing("🏁 TOTAL await_async TIME", now_ms() - start);
+        result
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn wait(self) -> Result<GpuMerkleOutput<F>> {
+        pollster::block_on(self.finish())
+    }
+}
+
+fn create_buffers(
+    ctx: &MerkleTreeGpuContext,
+    input: Buffer,
+    total_internal_nodes: usize,
+    cap_len: usize,
+) -> MerkleBuffers {
+    let nodes = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("merkle-nodes"),
+        size: (total_internal_nodes * BYTES_PER_DIGEST) as u64,
+        usage: wgpu::BufferUsages::STORAGE
+            | wgpu::BufferUsages::COPY_SRC
+            | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let cap = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("merkle-cap"),
+        size: (cap_len * BYTES_PER_DIGEST) as u64,
+        usage: wgpu::BufferUsages::STORAGE
+            | wgpu::BufferUsages::COPY_SRC
+            | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    MerkleBuffers { input, nodes, cap }
+}
+
+async fn wait_for_queue(queue_completion: Option<QueueCompletion>) -> Result<()> {
+    match queue_completion {
+        Some(completion) => {
+            log("wait_for_queue -> awaiting queue completion callback");
+            completion.wait().await?;
+            log("wait_for_queue -> completion callback resolved");
+            Ok(())
+        }
+        None => {
+            log("wait_for_queue -> skipped (no submissions recorded)");
+            Ok(())
+        }
+    }
+}
+
+struct HashSection<'a> {
+    label: &'static str,
+    buffer: &'a Buffer,
+    word_len: usize,
+}
+
+struct HashSectionResult<F: RichField> {
+    hashes: Vec<HashOut<F>>,
+    readback_ms: f64,
+    convert_ms: f64,
+}
+
+async fn read_hash_sections<F: RichField>(
+    context: &MerkleTreeGpuContext,
+    sections: &[HashSection<'_>],
+) -> Result<Vec<HashSectionResult<F>>> {
+    if sections.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let total_words: usize = sections.iter().map(|section| section.word_len).sum();
+    let total_bytes: u64 = sections
+        .iter()
+        .map(|section| (section.word_len * std::mem::size_of::<u32>()) as u64)
+        .sum();
+    let staging = context.get_or_make_staging(total_bytes);
+
+    context
+        .device
+        .push_error_scope(wgpu::ErrorFilter::Validation);
+
+    let mut encoder = context
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("merkle-combined-readback"),
+        });
+    let mut offsets_words = Vec::with_capacity(sections.len());
+    let mut offset_bytes = 0u64;
+    for section in sections {
+        let size_bytes = (section.word_len * std::mem::size_of::<u32>()) as u64;
+        encoder.copy_buffer_to_buffer(section.buffer, 0, &staging, offset_bytes, size_bytes);
+        offsets_words.push((offset_bytes / std::mem::size_of::<u32>() as u64) as usize);
+        offset_bytes += size_bytes;
+    }
+    let submission_index = context.queue.submit(Some(encoder.finish()));
+    log_queue_submission("combined_readback_copy", submission_index);
+
+    let slice = staging.slice(0..total_bytes);
+    let (map_tx, map_rx) = oneshot::channel();
+    let readback_id = READBACK_SEQ.fetch_add(1, Ordering::Relaxed);
+    let label = format!("combined_readback[{readback_id}]");
+    log_lazy(|| format!("{label} map_async registering"));
+    slice.map_async(wgpu::MapMode::Read, move |res| {
+        let _ = map_tx.send(res);
+    });
+
+    log_lazy(|| format!("{label} awaiting map_async completion"));
+    let copy_start = now_ms();
+    map_rx
+        .await
+        .map_err(|_| anyhow!("{label} map_async callback dropped"))?
+        .map_err(|err| anyhow!("{label} map_async error: {err:?}"))?;
+    let copy_elapsed = now_ms() - copy_start;
+
+    if let Some(err) =
+        pop_error_scope(context.device.clone(), format!("{label} validation scope")).await
+    {
+        return Err(anyhow!("validation error during readback: {err:?}"));
+    }
+
+    let data = slice.get_mapped_range();
+    let words_slice: &[u32] = bytemuck::cast_slice::<u8, u32>(&data);
+    let total_words_f = (total_words.max(1)) as f64;
+    let mut results = Vec::with_capacity(sections.len());
+    for (idx, section) in sections.iter().enumerate() {
+        let start = offsets_words[idx];
+        let end = start + section.word_len;
+        debug_assert!(
+            end <= words_slice.len(),
+            "{label} mapped words shorter than expected for {} section",
+            section.label
+        );
+        let convert_start = now_ms();
+        let hashes = words_slice[start..end]
+            .chunks(WORDS_PER_DIGEST)
+            .map(words_to_hash::<F>)
+            .collect::<Result<Vec<_>>>()?;
+        let convert_ms = now_ms() - convert_start;
+        let readback_ms = copy_elapsed * (section.word_len as f64) / total_words_f;
+        results.push(HashSectionResult {
+            hashes,
+            readback_ms,
+            convert_ms,
+        });
+    }
+    drop(data);
+    staging.unmap();
+    yield_to_event_loop().await;
+
+    Ok(results)
+}
+
+fn send_chunk_data<F: RichField>(ctx: &MerkleTreeGpuContext, leaves: &[Vec<F>]) -> Buffer {
+    //Result<(Vec<u32>, usize)> {
+    let num_leaves = leaves.len();
+    let elems_per_leaf = leaves[0].len();
+
+    const CHUNK_SIZE: usize = 1000;
+
+    let size = (num_leaves * elems_per_leaf * 2 * core::mem::size_of::<u32>()) as u64;
+    let dst = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("merkle-send-chunks"),
+        size,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let mut i = 0;
+    while i < num_leaves {
+        let start = i;
+        let upto = (num_leaves - i).min(CHUNK_SIZE);
+        let elems_this_chunk = upto * elems_per_leaf;
+
+        let offset_bytes = (start as u64) * (elems_per_leaf as u64) * 8;
+        let size_bytes = (elems_this_chunk as u64) * 8;
+
+        if let Some(mut view) =
+            ctx.queue
+                .write_buffer_with(&dst, offset_bytes, size_bytes.try_into().unwrap())
+        {
+            // SAFELY reinterpret &mut [u8] as &mut [u32] if alignment allows.
+            // align_to_mut() handles potential misalignment without UB.
+            let (head, out_u32, tail) = unsafe { view.align_to_mut::<u32>() };
+            debug_assert!(
+                head.is_empty() && tail.is_empty(),
+                "staging view not u32-aligned"
+            );
+
+            // We expect exactly 2 u32 words per element:
+            debug_assert_eq!(out_u32.len(), 2 * elems_this_chunk);
+
+            // Fill directly from field_to_words:
+            let mut idx = 0;
+            for leaf in &leaves[start..start + upto] {
+                for &val in &leaf[..elems_per_leaf] {
+                    let [lo, hi] = field_to_words(&val);
+                    out_u32[idx] = lo;
+                    out_u32[idx + 1] = hi;
+                    idx += 2;
+                }
+            }
+            // Dropping `view` schedules the copy; it transfers on the next queue.submit().
+        } else {
+            // Fallback: extremely unlikely unless validation fails.
+            // You could bail or fall back to a reusable Vec<u32> + write_buffer here.
+            panic!("write_buffer_with failed validation");
+        }
+
+        i += upto;
+    }
+
+    dst
+}
+
+/// Computes the required workgroup sizes in x and y to produce `num` threads.
+/// We assume a workgroup size of 64!
+fn compute_workgroups(num: usize) -> (u32, u32) {
+    const WORKGROUP_SIZE: usize = 64;
+    const MAX_DIM: usize = 1 << 16; // maximum dimension of a workgroup
+                                    // we divide `maxDim` by 2 so that the max X dim is 2^15 = 32768
+    let num_blocks = (num + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE;
+
+    let workgroups_y = if num_blocks >= MAX_DIM {
+        num_blocks / (MAX_DIM / 2)
+    } else {
+        1
+    };
+    let workgroups_x = (num_blocks + workgroups_y - 1) / workgroups_y;
+
+    (workgroups_x as u32, workgroups_y as u32)
+}
+
+fn hash_leaves_gpu(
+    ctx: &MerkleTreeGpuContext,
+    leaf_buf: Buffer,
+    num_leaves: usize,
+    elements_per_leaf: usize,
+) -> Result<(Buffer, SubmissionIndex)> {
+    // Time buffer creation
+    let buffer_start = now_ms();
+
+    let output_buffer = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("poseidon-leaf-output"),
+        size: (num_leaves * BYTES_PER_DIGEST) as u64,
+        usage: wgpu::BufferUsages::STORAGE
+            | wgpu::BufferUsages::COPY_SRC
+            | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    let num_leaves_i32 = num_leaves as i32;
+    let num_buffer = ctx
+        .device
+        .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("poseidon-leaf-count"),
+            contents: bytemuck::bytes_of(&num_leaves_i32),
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+        });
+
+    let elements_per_leaf_i32 = elements_per_leaf as i32;
+    let elements_buffer = ctx
+        .device
+        .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("poseidon-leaf-width"),
+            contents: bytemuck::bytes_of(&elements_per_leaf_i32),
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+        });
+
+    let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("poseidon-leaf-bind-group"),
+        layout: &ctx.leaf_bind_group_layout,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: output_buffer.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: leaf_buf.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: num_buffer.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 3,
+                resource: elements_buffer.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 4,
+                resource: ctx.mds_circ.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 5,
+                resource: ctx.mds_diag.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 6,
+                resource: ctx.round_constants.as_entire_binding(),
+            },
+        ],
+    });
+    log_timing_verbose(
+        "  Leaf buffer creation + bind group",
+        now_ms() - buffer_start,
+    );
+
+    // Time dispatch
+    let dispatch_start = now_ms();
+    let (workgroups_x, workgroups_y) = compute_workgroups(num_leaves);
+
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("poseidon-leaf-encoder"),
+        });
+
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("poseidon-leaf-pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&ctx.leaf_pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.dispatch_workgroups(workgroups_x, workgroups_y, 1);
+    }
+
+    let submission_index = ctx.queue.submit(Some(encoder.finish()));
+    log_queue_submission("hash_leaves_gpu", submission_index.clone());
+    log_timing_verbose("  Leaf dispatch", now_ms() - dispatch_start);
+
+    Ok((output_buffer, submission_index))
+}
+
+fn transpose_to_mont_gpu(
+    ctx: &MerkleTreeGpuContext,
+    input_buf: &Buffer,
+    num_leaves: usize,
+    elems_per_leaf: usize,
+) -> Result<(Buffer, SubmissionIndex)> {
+    let size = input_buf.size();
+    let output_buf = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("transpose-to-mont-output"),
+        size,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+        //usage: wgpu::BufferUsage::COPY_DST, // don'
+        mapped_at_creation: false,
+    });
+
+    let num_u32 = num_leaves as u32;
+    let num_buf = ctx
+        .device
+        .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("transpose-buf-num-leaves"),
+            contents: bytemuck::bytes_of(&num_u32),
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+        });
+    let elems_per_leaf_u32 = elems_per_leaf as u32;
+    let elems_per_leaf_buf = ctx
+        .device
+        .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("transpose-buf-elems-per-leaf"),
+            contents: bytemuck::bytes_of(&elems_per_leaf_u32),
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+        });
+
+    let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("to-montgomery-bind-group"),
+        layout: &ctx.transpose_to_mont_bind_group_layout,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: output_buf.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: input_buf.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: num_buf.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 3,
+                resource: elems_per_leaf_buf.as_entire_binding(),
+            },
+        ],
+    });
+    // Time dispatch
+    let dispatch_start = now_ms();
+
+    let bx = 16;
+    let by = 16;
+    let workgroups_x = (elems_per_leaf + bx - 1) / bx; // across columns;
+    let workgroups_y = (num_leaves + by - 1) / by; // across rows;
+
+    log::info!(
+        "Starting workgroups in (x, y) : ({}, {})",
+        workgroups_x,
+        workgroups_y
+    );
+
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("transpose-to-mont-encoder"),
+        });
+
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("transpose-to-mont-pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&ctx.transpose_to_mont_pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        //pass.dispatch_workgroups(workgroups_x, 1, 1);
+        pass.dispatch_workgroups(workgroups_x as u32, workgroups_y as u32, 1);
+    }
+
+    let submission_index = ctx.queue.submit(Some(encoder.finish()));
+    log_queue_submission("canonical_to_montgomery_gpu", submission_index.clone());
+    log_timing_verbose("  Canon->Mont dispatch", now_ms() - dispatch_start);
+
+    Ok((output_buf, submission_index))
+}
+
+/// Converts the input buffer from Montgomery representation into canonical representation
+/// to put it back into the form Plonky2 expects.
+/// `num` is the number of field elements in the buffer.
+fn montgomery_to_canonical_gpu(
+    ctx: &MerkleTreeGpuContext,
+    buf: &Buffer,
+    num: u32,
+) -> Option<SubmissionIndex> {
+    if num == 0 {
+        log("montgomery_to_canonical_gpu skipped (num == 0)");
+        return None;
+    }
+
+    // Time buffer creation
+    let buffer_start = now_ms();
+
+    let num_i32 = num as i32;
+    let num_buffer = ctx
+        .device
+        .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("buf-elems-count"),
+            contents: bytemuck::bytes_of(&num_i32),
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+        });
+
+    let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("to-montgomery-bind-group"),
+        layout: &ctx.to_canon_bind_group_layout,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: buf.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: num_buffer.as_entire_binding(),
+            },
+        ],
+    });
+    log_timing_verbose(
+        "  Mont->Canon buffer creation + bind group",
+        now_ms() - buffer_start,
+    );
+
+    // Time dispatch
+    let dispatch_start = now_ms();
+
+    let (workgroups_x, workgroups_y) = compute_workgroups(num as usize);
+
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("buf-mont-canon-encoder"),
+        });
+
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("buf-mont-canon-pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&ctx.to_canon_pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.dispatch_workgroups(workgroups_x, workgroups_y, 1);
+    }
+
+    let submission_index = ctx.queue.submit(Some(encoder.finish()));
+    log_queue_submission("montgomery_to_canonical_gpu", submission_index.clone());
+    log_timing_verbose("  Mont->Canon dispatch", now_ms() - dispatch_start);
+
+    Some(submission_index)
+}
+
+fn leaf_info<F>(leaves: &[Vec<F>]) -> (usize, usize)
+where
+    F: RichField + Poseidon,
+{
+    // TODO: Transpose the leaf nodes here
+    let num_leaves = leaves.len();
+    let elements_per_leaf = leaves[0].len();
+    (num_leaves, elements_per_leaf)
+}
+
+/// Run the GPU Merkle tree pipeline, returning a job that resolves once GPU buffers are ready.
+pub fn build_merkle_tree<F>(
+    ctx: Rc<MerkleTreeGpuContext>,
+    leaves: &[Vec<F>],
+    cap_height: usize,
+) -> Result<MerkleGpuJob<F>>
+where
+    F: RichField + Poseidon,
+{
+    let total_start = now_ms();
+
+    let ctx_ref = ctx.as_ref();
+    let mut saw_submission = false;
+
+    let (num_leaves, elements_per_leaf) = leaf_info(leaves);
+    let config_msg = format!(
+        "GPU Merkle config -> leaves: {num_leaves}, elements_per_leaf: {elements_per_leaf}, cap_height: {cap_height}"
+    );
+    log(&config_msg);
+    ensure!(num_leaves > 0, "Merkle tree requires at least one leaf");
+    ensure!(
+        num_leaves <= i32::MAX as usize,
+        "Merkle GPU hashing expects leaf count to fit in i32, got {num_leaves}"
+    );
+    ensure!(
+        leaves.iter().all(|leaf| leaf.len() == elements_per_leaf),
+        "GPU Poseidon hashing requires leaves of uniform length"
+    );
+    ensure!(
+        num_leaves.is_power_of_two(),
+        "GPU Merkle currently expects a power-of-two leaf count"
+    );
+
+    let depth = num_leaves.trailing_zeros() as usize;
+    ensure!(
+        cap_height <= depth,
+        "cap_height {cap_height} exceeds tree depth {depth}"
+    );
+    let depth_msg = format!("GPU Merkle depth -> depth: {depth}");
+    log(&depth_msg);
+
+    let num_layers_to_root = depth;
+    let num_layers_to_cap = num_layers_to_root - cap_height;
+    let cap_len = 1usize << cap_height;
+
+    let total_nodes: usize = (1..num_layers_to_cap)
+        .map(|layer| host_layer_size(num_leaves, layer))
+        .sum();
+    let sizing_msg = format!(
+        "GPU Merkle sizing -> num_layers_to_root: {num_layers_to_root}, num_layers_to_cap: {num_layers_to_cap}, cap_len: {cap_len}, total_internal_nodes: {total_nodes}"
+    );
+    log(&sizing_msg);
+
+    if total_nodes == 0 {
+        let fallback_msg = format!(
+            "GPU Merkle fallback: total_internal_nodes is zero (leaves={num_leaves}, cap_height={cap_height}, num_layers_to_cap={num_layers_to_cap}). Falling back to CPU."
+        );
+        log(&fallback_msg);
+        return Err(anyhow!(
+            "GPU Merkle skipped: total_internal_nodes == 0 for leaves={num_leaves}, cap_height={cap_height}"
+        ));
+    }
+
+    // Time data conversion
+    //let convert_start = now_ms();
+    ensure!(
+        elements_per_leaf > 0,
+        "GPU Poseidon hashing received empty leaves"
+    );
+    ensure!(
+        elements_per_leaf <= i32::MAX as usize,
+        "elements_per_leaf must fit in i32, got {elements_per_leaf}"
+    );
+    //log_timing("  Leaf data transpose", now_ms() - convert_start);
+
+    // TODO: Perform single canonical -> Montgomery representation pass on inputs
+
+    // 4. Send data in chunks to the GPU and then transpose + Montgomery convert on GPU
+    let chunk_send_start = now_ms();
+    let input_buf = send_chunk_data(&ctx, leaves);
+    let chunk_send_stop = now_ms();
+    log_timing(
+        "    Sending data in chunks to GPU",
+        chunk_send_stop - chunk_send_start,
+    );
+
+    // Convert canonical words into Montgomery form via the GPU pipeline
+    let canon_to_mont_start = now_ms();
+    let (input_buffer, _submission_index) =
+        //canonical_to_montgomery_gpu(&ctx, &canonical_words, num_leaves * elements_per_leaf)?;
+        transpose_to_mont_gpu(&ctx, &input_buf, num_leaves, elements_per_leaf)?;
+    if !saw_submission {
+        saw_submission = true;
+    }
+    log_timing(
+        "  Leaf data Canonical -> Montgomery conversion",
+        now_ms() - canon_to_mont_start,
+    );
+    // Release the large canonical word buffer before launching downstream GPU work.
+    //drop(canonical_words);
+
+    // TODO: After main Merkle tree kernel calls: single Montgomery -> canonical pass for all digsts / nodes
+
+    // PHASE 1: Leaf hashing setup and dispatch
+    log("=== PHASE 1: Leaf Hashing ===");
+    let leaf_start = now_ms();
+    log("launching GPU Poseidon hashing");
+    let (leaf_buffer, _submission_index) =
+        hash_leaves_gpu(ctx_ref, input_buffer, num_leaves, elements_per_leaf)?;
+    if !saw_submission {
+        saw_submission = true;
+    }
+    log("queued GPU Poseidon hashing");
+    log_timing_verbose("Leaf hash setup + dispatch", now_ms() - leaf_start);
+
+    // PHASE 2: Buffer allocation
+    log("=== PHASE 2: Buffer Creation ===");
+
+    let buffer_start = now_ms();
+    let buffers = create_buffers(ctx_ref, leaf_buffer, total_nodes, cap_len);
+    log_timing_verbose("Buffer allocation", now_ms() - buffer_start);
+
+    // PHASE 3: Layer processing
+    log_lazy(|| format!(
+        "=== PHASE 3: Layer Processing ({} layers) ===",
+        num_layers_to_cap
+    ));
+    let layer_setup_start = now_ms();
+
+    for layer in 0..num_layers_to_cap {
+        let layer_start = now_ms();
+
+        log_lazy(|| format!("layer: {}", layer));
+        let src_layer_size = host_layer_size(num_leaves, layer);
+        let dst_layer_size = host_layer_size(num_leaves, layer + 1);
+        let src_offset = if layer == 0 {
+            0
+        } else {
+            host_layer_offset(num_leaves, layer)
+        };
+        let dst_offset = if layer + 1 < num_layers_to_cap {
+            host_layer_offset(num_leaves, layer + 1)
+        } else {
+            0
+        };
+        let write_to_cap = (layer + 1) == num_layers_to_cap;
+        log_lazy(|| {
+            format!(
+                "  layer sizes -> layer: {layer}, src_layer_size: {src_layer_size}, dst_layer_size: {dst_layer_size}, src_offset: {src_offset}, dst_offset: {dst_offset}, write_to_cap: {write_to_cap}"
+            )
+        });
+
+        let args = MerkleTreeKernelArgs {
+            cap_len: cap_len as u32,
+            layer: layer as u32,
+            src_layer_size: src_layer_size as u32,
+            dst_layer_size: dst_layer_size as u32,
+            src_offset: src_offset as u32,
+            dst_offset: dst_offset as u32,
+            write_to_cap: write_to_cap as u32,
+        };
+
+        // Time bind group creation
+        let bind_start = now_ms();
+        let args_buffer = ctx_ref
+            .device
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some(&format!("merkle-layer-args-{layer}")),
+                contents: bytemuck::bytes_of(&args),
+                usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            });
+
+        let bind_group = ctx_ref
+            .device
+            .create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some(&format!("merkle-layer-bind-group-{layer}")),
+                layout: &ctx_ref.merkle_bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: buffers.input.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: buffers.nodes.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: buffers.cap.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 3,
+                        resource: args_buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 4,
+                        resource: ctx_ref.mds_circ.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 5,
+                        resource: ctx_ref.mds_diag.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 6,
+                        resource: ctx_ref.round_constants.as_entire_binding(),
+                    },
+                ],
+            });
+        let bind_time = now_ms() - bind_start;
+
+        // Time encoder creation and dispatch
+        let encode_start = now_ms();
+        let mut encoder = ctx_ref
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some(&format!("merkle-layer-{layer}-encoder")),
+            });
+
+        log("execute layer");
+
+        let (workgroups_x, workgroups_y) = compute_workgroups(dst_layer_size);
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some(&format!("merkle-layer-{layer}-pass")),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&ctx_ref.merkle_pipeline);
+            pass.set_bind_group(0, &bind_group, &[]);
+            pass.dispatch_workgroups(workgroups_x, workgroups_y, 1);
+        }
+        let encode_time = now_ms() - encode_start;
+
+        // Time submission (should be fast)
+        let submit_start = now_ms();
+        let submission_index = ctx_ref.queue.submit(Some(encoder.finish()));
+        log_lazy(|| {
+            format!(
+                "📤 Queue submit -> merkle_layer_{layer} (submission_index={submission_index:?})"
+            )
+        });
+        if !saw_submission {
+            saw_submission = true;
+        }
+        let submit_time = now_ms() - submit_start;
+
+        let layer_time = now_ms() - layer_start;
+        log_lazy(|| {
+            format!(
+                "  Layer {}: total={:.2}ms (bind={:.2}ms, encode={:.2}ms, submit={:.2}ms)",
+                layer, layer_time, bind_time, encode_time, submit_time
+            )
+        });
+    }
+
+    // Convert input buffer (leaf nodes) from Montgomery into canonical repr
+    if montgomery_to_canonical_gpu(
+        ctx_ref,
+        &buffers.input,
+        (num_leaves * NUM_HASH_OUT_ELTS) as u32,
+    )
+    .is_some()
+    {
+        if !saw_submission {
+            saw_submission = true;
+        }
+    }
+    if montgomery_to_canonical_gpu(
+        ctx_ref,
+        &buffers.nodes,
+        (total_nodes * NUM_HASH_OUT_ELTS) as u32,
+    )
+    .is_some()
+    {
+        if !saw_submission {
+            saw_submission = true;
+        }
+    }
+
+    let total_layer_time = now_ms() - layer_setup_start;
+    log_timing_verbose("Total layer setup + dispatch", total_layer_time);
+
+    log("queued GPU Merkle buffers");
+
+    let total_setup_time = now_ms() - total_start;
+    log_timing(
+        "🔧 TOTAL SETUP TIME (everything before GPU wait)",
+        total_setup_time,
+    );
+
+    if !saw_submission {
+        log("Merkle GPU pipeline recorded no queue submissions before wait (unexpected)");
+    }
+
+    let queue_completion = if saw_submission {
+        Some(QueueCompletion::new(ctx.queue.clone()))
+    } else {
+        None
+    };
+
+    Ok(MerkleGpuJob::deferred(
+        ctx,
+        buffers,
+        total_nodes,
+        cap_len,
+        num_leaves,
+        cap_height,
+        num_layers_to_cap,
+        queue_completion,
+    ))
+}
+
+struct SubtreeFrame {
+    start: usize,
+    len: usize,
+    leaf_offset: usize,
+    leaves_len: usize,
+    layer_index: usize,
+}
+
+fn write_subtree_chunk_from_gpu<F: RichField>(
+    chunk: &mut [HashOut<F>],
+    accessor: &LayerAccessor<'_, F>,
+    leaf_offset: usize,
+    subtree_leaves_len: usize,
+) {
+    if chunk.is_empty() {
+        debug_assert_eq!(subtree_leaves_len, 1);
+        return;
+    }
+
+    let mut stack = vec![SubtreeFrame {
+        start: 0,
+        len: chunk.len(),
+        leaf_offset,
+        leaves_len: subtree_leaves_len,
+        layer_index: accessor.cap_layer(),
+    }];
+
+    while let Some(frame) = stack.pop() {
+        if frame.leaves_len <= 1 || frame.len == 0 {
+            continue;
+        }
+        debug_assert!(frame.layer_index > 0);
+        debug_assert_eq!(frame.len, 2 * (frame.leaves_len - 1));
+
+        let half_leaves = frame.leaves_len / 2;
+        let chunk_half = frame.len / 2;
+        let left_slot = frame.start + chunk_half - 1;
+        let right_slot = frame.start + chunk_half;
+        let child_layer = frame.layer_index - 1;
+
+        let left_node_idx = frame.leaf_offset >> child_layer;
+        let right_leaf_offset = frame.leaf_offset + half_leaves;
+        let right_node_idx = right_leaf_offset >> child_layer;
+
+        chunk[left_slot] = accessor.node(child_layer, left_node_idx).clone();
+        chunk[right_slot] = accessor.node(child_layer, right_node_idx).clone();
+
+        let subtree_len = chunk_half - 1;
+        if subtree_len > 0 {
+            stack.push(SubtreeFrame {
+                start: right_slot + 1,
+                len: subtree_len,
+                leaf_offset: right_leaf_offset,
+                leaves_len: half_leaves,
+                layer_index: child_layer,
+            });
+            stack.push(SubtreeFrame {
+                start: frame.start,
+                len: subtree_len,
+                leaf_offset: frame.leaf_offset,
+                leaves_len: half_leaves,
+                layer_index: child_layer,
+            });
+        }
+    }
+}
+
+struct LayerAccessor<'a, F: RichField> {
+    leaf_hashes: &'a [HashOut<F>],
+    node_hashes: &'a [HashOut<F>],
+    cap_hashes: &'a [HashOut<F>],
+    layer_starts: Vec<usize>,
+    num_layers_to_cap: usize,
+}
+
+impl<'a, F: RichField> LayerAccessor<'a, F> {
+    fn new(
+        leaf_hashes: &'a [HashOut<F>],
+        node_hashes: &'a [HashOut<F>],
+        cap_hashes: &'a [HashOut<F>],
+        num_leaves: usize,
+        num_layers_to_cap: usize,
+    ) -> Self {
+        let mut layer_starts = vec![0usize; num_layers_to_cap];
+        let mut acc = 0;
+        for layer in 1..num_layers_to_cap {
+            layer_starts[layer] = acc;
+            acc += host_layer_size(num_leaves, layer);
+        }
+        debug_assert_eq!(acc, node_hashes.len());
+        Self {
+            leaf_hashes,
+            node_hashes,
+            cap_hashes,
+            layer_starts,
+            num_layers_to_cap,
+        }
+    }
+
+    fn node(&self, layer: usize, node_idx: usize) -> &HashOut<F> {
+        match layer {
+            0 => &self.leaf_hashes[node_idx],
+            l if l < self.num_layers_to_cap => {
+                let start = self.layer_starts[l];
+                &self.node_hashes[start + node_idx]
+            }
+            l if l == self.num_layers_to_cap => &self.cap_hashes[node_idx],
+            _ => panic!("layer {layer} out of bounds"),
+        }
+    }
+
+    fn cap_layer(&self) -> usize {
+        self.num_layers_to_cap
+    }
+}
+
+/// Attempt to build the Merkle tree using the GPU path. Returns `None` if the GPU context has not
+/// been initialised.
+pub fn try_build_merkle_tree<F>(
+    leaves: &[Vec<F>],
+    cap_height: usize,
+) -> Option<Result<MerkleGpuJob<F>>>
+where
+    F: RichField + Poseidon,
+{
+    let context = GPU_CONTEXT.with(|cell| cell.get().cloned());
+    let context = match context {
+        Some(ctx) => ctx,
+        None => {
+            return None;
+        }
+    };
+
+    Some(build_merkle_tree::<F>(context, leaves, cap_height))
+}
+
+/// GPU Merkle output that mirrors the CPU layout.
+#[derive(Debug)]
+pub struct GpuMerkleOutput<F: RichField> {
+    pub digests: Vec<HashOut<F>>,
+    pub cap: Vec<HashOut<F>>,
+}

--- a/plonky2/src/hash/merkle_tree_gpu.rs
+++ b/plonky2/src/hash/merkle_tree_gpu.rs
@@ -955,55 +955,80 @@ where
                     .into(),
                 );
 
-                let mut sections = Vec::with_capacity(3);
-                sections.push(HashSection {
-                    label: "Leaf",
-                    buffer: &buffers.input,
-                    word_len: num_leaves * WORDS_PER_DIGEST,
-                });
-                if total_nodes > 0 {
-                    sections.push(HashSection {
-                        label: "Node",
-                        buffer: &buffers.nodes,
-                        word_len: total_nodes * WORDS_PER_DIGEST,
+                // Read back raw words from GPU without decoding into HashOut Vecs
+                // to avoid ~32MB of intermediate allocations at high memory pressure.
+                let leaf_words = num_leaves * WORDS_PER_DIGEST;
+                let node_words = total_nodes * WORDS_PER_DIGEST;
+                let cap_words = cap_len * WORDS_PER_DIGEST;
+                let total_words = leaf_words + node_words + cap_words;
+                let total_bytes = (total_words * std::mem::size_of::<u32>()) as u64;
+
+                #[cfg(target_arch = "wasm32")]
+                web_sys::console::log_1(
+                    &format!("read_raw: total_bytes={}, getting staging buffer", total_bytes).into(),
+                );
+
+                let staging = context.get_or_make_staging(total_bytes);
+
+                context
+                    .device
+                    .push_error_scope(wgpu::ErrorFilter::Validation);
+
+                let mut encoder = context
+                    .device
+                    .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                        label: Some("merkle-combined-readback"),
                     });
+                let mut offset_bytes = 0u64;
+                // Leaf
+                let leaf_bytes = (leaf_words * std::mem::size_of::<u32>()) as u64;
+                encoder.copy_buffer_to_buffer(&buffers.input, 0, &staging, offset_bytes, leaf_bytes);
+                offset_bytes += leaf_bytes;
+                // Node
+                if total_nodes > 0 {
+                    let node_bytes = (node_words * std::mem::size_of::<u32>()) as u64;
+                    encoder.copy_buffer_to_buffer(&buffers.nodes, 0, &staging, offset_bytes, node_bytes);
+                    offset_bytes += node_bytes;
                 }
-                sections.push(HashSection {
-                    label: "Cap",
-                    buffer: &buffers.cap,
-                    word_len: cap_len * WORDS_PER_DIGEST,
+                // Cap
+                let cap_bytes = (cap_words * std::mem::size_of::<u32>()) as u64;
+                encoder.copy_buffer_to_buffer(&buffers.cap, 0, &staging, offset_bytes, cap_bytes);
+
+                let submission_index = context.queue.submit(Some(encoder.finish()));
+                log_queue_submission("combined_readback_copy", submission_index);
+
+                let slice = staging.slice(0..total_bytes);
+                let (map_tx, map_rx) = oneshot::channel();
+                slice.map_async(wgpu::MapMode::Read, move |res| {
+                    let _ = map_tx.send(res);
                 });
-                let section_results = read_hash_sections::<F>(&context, &sections).await?;
-                debug_assert_eq!(section_results.len(), sections.len());
-                let mut section_iter = section_results.into_iter();
 
-                let leaf_result = section_iter
-                    .next()
-                    .expect("leaf section missing from combined readback");
-                log_timing_verbose("Leaf hash readback", leaf_result.readback_ms);
-                log_timing_verbose("Leaf canonical decode", leaf_result.convert_ms);
-                let leaf_hashes = leaf_result.hashes;
+                map_rx
+                    .await
+                    .map_err(|_| anyhow!("map_async callback dropped"))?
+                    .map_err(|err| anyhow!("map_async error: {err:?}"))?;
 
-                let (node_hashes, cap_result) = if total_nodes > 0 {
-                    let node_result = section_iter
-                        .next()
-                        .expect("node section missing from combined readback");
-                    log_timing_verbose("Node hash readback", node_result.readback_ms);
-                    log_timing_verbose("Node canonical decode", node_result.convert_ms);
-                    let cap_result = section_iter
-                        .next()
-                        .expect("cap section missing from combined readback");
-                    (node_result.hashes, cap_result)
-                } else {
-                    let cap_result = section_iter
-                        .next()
-                        .expect("cap section missing from combined readback");
-                    (Vec::new(), cap_result)
-                };
-                debug_assert!(section_iter.next().is_none());
-                log_timing_verbose("Cap readback", cap_result.readback_ms);
-                log_timing_verbose("Cap canonical decode", cap_result.convert_ms);
-                let cap_hashes = cap_result.hashes;
+                if let Some(err) =
+                    pop_error_scope(context.device.clone(), "readback validation".to_string()).await
+                {
+                    return Err(anyhow!("validation error during readback: {err:?}"));
+                }
+
+                let data = slice.get_mapped_range();
+                let words_slice: &[u32] = bytemuck::cast_slice::<u8, u32>(&data);
+
+                #[cfg(target_arch = "wasm32")]
+                web_sys::console::log_1(
+                    &format!("read_raw: mapped {} words, decoding cap only", words_slice.len()).into(),
+                );
+
+                // Only decode cap hashes into a Vec (tiny: 16 elements).
+                // Leaf and node hashes are accessed on-the-fly from words_slice.
+                let cap_start = leaf_words + node_words;
+                let cap_hashes: Vec<HashOut<F>> = words_slice[cap_start..cap_start + cap_words]
+                    .chunks(WORDS_PER_DIGEST)
+                    .map(words_to_hash::<F>)
+                    .collect::<Result<Vec<_>>>()?;
 
                 // CPU post-processing: reconstruct digest tree
                 log("=== PHASE 5: CPU Post-processing ===");
@@ -1012,9 +1037,10 @@ where
                 let num_digests = 2 * (num_leaves - (1 << cap_height));
                 let digests = if num_digests > 0 {
                     let mut digests = vec![HashOut::<F>::ZERO; num_digests];
-                    let accessor = LayerAccessor::new(
-                        &leaf_hashes,
-                        &node_hashes,
+                    let accessor = RawLayerAccessor::new(
+                        words_slice,
+                        leaf_words,
+                        node_words,
                         &cap_hashes,
                         num_leaves,
                         num_layers_to_cap,
@@ -1033,10 +1059,6 @@ where
                             leaf_offset,
                             subtree_leaves_len,
                         );
-                        debug_assert_eq!(
-                            accessor.node(accessor.cap_layer(), subtree_idx),
-                            &cap_hashes[subtree_idx]
-                        );
                     }
 
                     digests
@@ -1045,6 +1067,10 @@ where
                 };
 
                 log_timing_verbose("Digest tree reconstruction", now_ms() - postprocess_start);
+
+                drop(data);
+                staging.unmap();
+                yield_to_event_loop().await;
 
                 log_timing_verbose(
                     "📥 TOTAL READBACK + POST-PROCESSING",
@@ -1974,9 +2000,14 @@ struct SubtreeFrame {
     layer_index: usize,
 }
 
-fn write_subtree_chunk_from_gpu<F: RichField>(
+trait MerkleLayerAccess<F: RichField> {
+    fn node(&self, layer: usize, node_idx: usize) -> HashOut<F>;
+    fn cap_layer(&self) -> usize;
+}
+
+fn write_subtree_chunk_from_gpu<F: RichField, A: MerkleLayerAccess<F>>(
     chunk: &mut [HashOut<F>],
-    accessor: &LayerAccessor<'_, F>,
+    accessor: &A,
     leaf_offset: usize,
     subtree_leaves_len: usize,
 ) {
@@ -2010,8 +2041,8 @@ fn write_subtree_chunk_from_gpu<F: RichField>(
         let right_leaf_offset = frame.leaf_offset + half_leaves;
         let right_node_idx = right_leaf_offset >> child_layer;
 
-        chunk[left_slot] = accessor.node(child_layer, left_node_idx).clone();
-        chunk[right_slot] = accessor.node(child_layer, right_node_idx).clone();
+        chunk[left_slot] = accessor.node(child_layer, left_node_idx);
+        chunk[right_slot] = accessor.node(child_layer, right_node_idx);
 
         let subtree_len = chunk_half - 1;
         if subtree_len > 0 {
@@ -2065,14 +2096,83 @@ impl<'a, F: RichField> LayerAccessor<'a, F> {
         }
     }
 
-    fn node(&self, layer: usize, node_idx: usize) -> &HashOut<F> {
+}
+
+impl<'a, F: RichField> MerkleLayerAccess<F> for LayerAccessor<'a, F> {
+    fn node(&self, layer: usize, node_idx: usize) -> HashOut<F> {
         match layer {
-            0 => &self.leaf_hashes[node_idx],
+            0 => self.leaf_hashes[node_idx],
             l if l < self.num_layers_to_cap => {
                 let start = self.layer_starts[l];
-                &self.node_hashes[start + node_idx]
+                self.node_hashes[start + node_idx]
             }
-            l if l == self.num_layers_to_cap => &self.cap_hashes[node_idx],
+            l if l == self.num_layers_to_cap => self.cap_hashes[node_idx],
+            _ => panic!("layer {layer} out of bounds"),
+        }
+    }
+
+    fn cap_layer(&self) -> usize {
+        self.num_layers_to_cap
+    }
+}
+
+/// Like LayerAccessor but reads hashes on-the-fly from raw u32 words,
+/// avoiding large Vec<HashOut<F>> allocations.
+struct RawLayerAccessor<'a, F: RichField> {
+    words: &'a [u32],
+    leaf_words_len: usize,
+    cap_hashes: &'a [HashOut<F>],
+    layer_starts: Vec<usize>,
+    num_layers_to_cap: usize,
+}
+
+impl<'a, F: RichField> RawLayerAccessor<'a, F> {
+    fn new(
+        words: &'a [u32],
+        leaf_words_len: usize,
+        _node_words_len: usize,
+        cap_hashes: &'a [HashOut<F>],
+        num_leaves: usize,
+        num_layers_to_cap: usize,
+    ) -> Self {
+        let mut layer_starts = vec![0usize; num_layers_to_cap];
+        let mut acc = 0;
+        for layer in 1..num_layers_to_cap {
+            layer_starts[layer] = acc;
+            acc += host_layer_size(num_leaves, layer);
+        }
+        Self {
+            words,
+            leaf_words_len,
+            cap_hashes,
+            layer_starts,
+            num_layers_to_cap,
+        }
+    }
+
+    fn read_hash_at_word_offset(&self, word_offset: usize) -> HashOut<F> {
+        let w = &self.words[word_offset..word_offset + WORDS_PER_DIGEST];
+        // Safety: from_canonical_u64 is a no-op in release (debug_assert only)
+        let mut elements = [F::ZERO; NUM_HASH_OUT_ELTS];
+        for (i, chunk) in w.chunks(BIGINT_LIMBS).enumerate() {
+            let canon = (chunk[1] as u64) << 32 | (chunk[0] as u64);
+            elements[i] = F::from_canonical_u64(canon);
+        }
+        HashOut { elements }
+    }
+}
+
+impl<'a, F: RichField> MerkleLayerAccess<F> for RawLayerAccessor<'a, F> {
+    fn node(&self, layer: usize, node_idx: usize) -> HashOut<F> {
+        match layer {
+            0 => self.read_hash_at_word_offset(node_idx * WORDS_PER_DIGEST),
+            l if l < self.num_layers_to_cap => {
+                let start = self.layer_starts[l];
+                self.read_hash_at_word_offset(
+                    self.leaf_words_len + (start + node_idx) * WORDS_PER_DIGEST,
+                )
+            }
+            l if l == self.num_layers_to_cap => self.cap_hashes[node_idx],
             _ => panic!("layer {layer} out of bounds"),
         }
     }

--- a/plonky2/src/hash/merkle_tree_gpu.rs
+++ b/plonky2/src/hash/merkle_tree_gpu.rs
@@ -1936,13 +1936,7 @@ impl<'a, F: RichField> RawLayerAccessor<'a, F> {
 
     fn read_hash_at_word_offset(&self, word_offset: usize) -> HashOut<F> {
         let w = &self.words[word_offset..word_offset + WORDS_PER_DIGEST];
-        // Safety: from_canonical_u64 is a no-op in release (debug_assert only)
-        let mut elements = [F::ZERO; NUM_HASH_OUT_ELTS];
-        for (i, chunk) in w.chunks(BIGINT_LIMBS).enumerate() {
-            let canon = (chunk[1] as u64) << 32 | (chunk[0] as u64);
-            elements[i] = F::from_canonical_u64(canon);
-        }
-        HashOut { elements }
+        words_to_hash::<F>(w).expect("invalid digest words in staging buffer")
     }
 }
 

--- a/plonky2/src/hash/merkle_tree_gpu.rs
+++ b/plonky2/src/hash/merkle_tree_gpu.rs
@@ -38,7 +38,7 @@ const ROUND_CONSTANT_COUNT: usize = POSEIDON_WIDTH * poseidon::N_ROUNDS;
 
 // for `now` for timing
 use js_sys::Promise;
-use wasm_bindgen::{prelude::*, JsCast};
+use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
 thread_local! {
@@ -169,17 +169,6 @@ fn field_to_words<F: RichField>(value: &F) -> [u32; BIGINT_LIMBS] {
 
 fn words_to_field<F: RichField>(words: &[u32; BIGINT_LIMBS]) -> F {
     let canon = (words[1] as u64) << 32 | (words[0] as u64);
-    // Goldilocks modulus: 2^64 - 2^32 + 1 = 18446744069414584321
-    if canon >= 18446744069414584321u64 {
-        #[cfg(target_arch = "wasm32")]
-        web_sys::console::error_1(
-            &format!(
-                "ERROR: non-canonical value from GPU: {} (words: [{:#010x}, {:#010x}])",
-                canon, words[0], words[1]
-            )
-            .into(),
-        );
-    }
     F::from_canonical_u64(canon)
 }
 
@@ -946,15 +935,6 @@ where
                 wait_for_queue(queue_completion).await?;
                 log_timing("⚡ GPU execution (wait_for_queue)", now_ms() - wait_start);
 
-                #[cfg(target_arch = "wasm32")]
-                web_sys::console::log_1(
-                    &format!(
-                        "GPU done. Tree info: num_leaves={}, total_nodes={}, cap_len={}, cap_height={}",
-                        num_leaves, total_nodes, cap_len, cap_height
-                    )
-                    .into(),
-                );
-
                 // Read back raw words from GPU without decoding into HashOut Vecs
                 // to avoid ~32MB of intermediate allocations at high memory pressure.
                 let leaf_words = num_leaves * WORDS_PER_DIGEST;
@@ -962,11 +942,6 @@ where
                 let cap_words = cap_len * WORDS_PER_DIGEST;
                 let total_words = leaf_words + node_words + cap_words;
                 let total_bytes = (total_words * std::mem::size_of::<u32>()) as u64;
-
-                #[cfg(target_arch = "wasm32")]
-                web_sys::console::log_1(
-                    &format!("read_raw: total_bytes={}, getting staging buffer", total_bytes).into(),
-                );
 
                 let staging = context.get_or_make_staging(total_bytes);
 
@@ -1017,11 +992,6 @@ where
                 let data = slice.get_mapped_range();
                 let words_slice: &[u32] = bytemuck::cast_slice::<u8, u32>(&data);
 
-                #[cfg(target_arch = "wasm32")]
-                web_sys::console::log_1(
-                    &format!("read_raw: mapped {} words, decoding cap only", words_slice.len()).into(),
-                );
-
                 // Only decode cap hashes into a Vec (tiny: 16 elements).
                 // Leaf and node hashes are accessed on-the-fly from words_slice.
                 let cap_start = leaf_words + node_words;
@@ -1048,7 +1018,6 @@ where
                     let subtree_digests_len = num_digests >> cap_height;
                     let subtree_leaves_len = num_leaves >> cap_height;
 
-                    log("Subtree business");
                     for (subtree_idx, subtree_buf) in
                         digests.chunks_mut(subtree_digests_len).enumerate()
                     {
@@ -1139,191 +1108,6 @@ async fn wait_for_queue(queue_completion: Option<QueueCompletion>) -> Result<()>
             Ok(())
         }
     }
-}
-
-struct HashSection<'a> {
-    label: &'static str,
-    buffer: &'a Buffer,
-    word_len: usize,
-}
-
-struct HashSectionResult<F: RichField> {
-    hashes: Vec<HashOut<F>>,
-    readback_ms: f64,
-    convert_ms: f64,
-}
-
-async fn read_hash_sections<F: RichField>(
-    context: &MerkleTreeGpuContext,
-    sections: &[HashSection<'_>],
-) -> Result<Vec<HashSectionResult<F>>> {
-    if sections.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let total_words: usize = sections.iter().map(|section| section.word_len).sum();
-    let total_bytes: u64 = sections
-        .iter()
-        .map(|section| (section.word_len * std::mem::size_of::<u32>()) as u64)
-        .sum();
-
-    #[cfg(target_arch = "wasm32")]
-    web_sys::console::log_1(
-        &format!("read_hash_sections: total_bytes={}, getting staging buffer", total_bytes).into(),
-    );
-
-    let staging = context.get_or_make_staging(total_bytes);
-
-    #[cfg(target_arch = "wasm32")]
-    web_sys::console::log_1(&"read_hash_sections: staging buffer acquired, encoding copies".into());
-
-    context
-        .device
-        .push_error_scope(wgpu::ErrorFilter::Validation);
-
-    let mut encoder = context
-        .device
-        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-            label: Some("merkle-combined-readback"),
-        });
-    let mut offsets_words = Vec::with_capacity(sections.len());
-    let mut offset_bytes = 0u64;
-    for section in sections {
-        let size_bytes = (section.word_len * std::mem::size_of::<u32>()) as u64;
-        encoder.copy_buffer_to_buffer(section.buffer, 0, &staging, offset_bytes, size_bytes);
-        offsets_words.push((offset_bytes / std::mem::size_of::<u32>() as u64) as usize);
-        offset_bytes += size_bytes;
-    }
-    let submission_index = context.queue.submit(Some(encoder.finish()));
-    log_queue_submission("combined_readback_copy", submission_index);
-
-    #[cfg(target_arch = "wasm32")]
-    web_sys::console::log_1(&"read_hash_sections: copies submitted, starting map_async".into());
-
-    let slice = staging.slice(0..total_bytes);
-    let (map_tx, map_rx) = oneshot::channel();
-    let readback_id = READBACK_SEQ.fetch_add(1, Ordering::Relaxed);
-    let label = format!("combined_readback[{readback_id}]");
-    log_lazy(|| format!("{label} map_async registering"));
-    slice.map_async(wgpu::MapMode::Read, move |res| {
-        let _ = map_tx.send(res);
-    });
-
-    log_lazy(|| format!("{label} awaiting map_async completion"));
-    let copy_start = now_ms();
-    map_rx
-        .await
-        .map_err(|_| anyhow!("{label} map_async callback dropped"))?
-        .map_err(|err| anyhow!("{label} map_async error: {err:?}"))?;
-    let copy_elapsed = now_ms() - copy_start;
-
-    #[cfg(target_arch = "wasm32")]
-    web_sys::console::log_1(
-        &format!("read_hash_sections: map_async completed in {:.2}ms", copy_elapsed).into(),
-    );
-
-    if let Some(err) =
-        pop_error_scope(context.device.clone(), format!("{label} validation scope")).await
-    {
-        return Err(anyhow!("validation error during readback: {err:?}"));
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    web_sys::console::log_1(&"read_hash_sections: no validation errors, reading mapped range".into());
-
-    let data = slice.get_mapped_range();
-    let words_slice: &[u32] = bytemuck::cast_slice::<u8, u32>(&data);
-    let total_words_f = (total_words.max(1)) as f64;
-    let mut results = Vec::with_capacity(sections.len());
-    for (idx, section) in sections.iter().enumerate() {
-        let start = offsets_words[idx];
-        let end = start + section.word_len;
-        #[cfg(target_arch = "wasm32")]
-        web_sys::console::log_1(
-            &format!(
-                "Decoding {} section: {} words ({} hashes), slice range [{}..{}], total buffer words: {}",
-                section.label,
-                section.word_len,
-                section.word_len / WORDS_PER_DIGEST,
-                start,
-                end,
-                words_slice.len()
-            )
-            .into(),
-        );
-        if end > words_slice.len() {
-            return Err(anyhow!(
-                "{} section out of bounds: need [{}..{}] but buffer only has {} words",
-                section.label,
-                start,
-                end,
-                words_slice.len()
-            ));
-        }
-        let convert_start = now_ms();
-        let num_hashes = section.word_len / WORDS_PER_DIGEST;
-        #[cfg(target_arch = "wasm32")]
-        {
-            let mem = wasm_bindgen::memory().dyn_into::<js_sys::WebAssembly::Memory>().unwrap();
-            let buf = mem.buffer();
-            let buf_size = if let Ok(ab) = buf.dyn_into::<js_sys::ArrayBuffer>() {
-                ab.byte_length()
-            } else {
-                let sab = mem.buffer().dyn_into::<js_sys::SharedArrayBuffer>().unwrap();
-                sab.byte_length()
-            };
-            let alloc_bytes = num_hashes * std::mem::size_of::<HashOut<F>>();
-            web_sys::console::log_1(
-                &format!(
-                    "  {} section: WASM memory={:.1}MB, allocating Vec for {} hashes ({:.1}MB)",
-                    section.label,
-                    buf_size as f64 / (1024.0 * 1024.0),
-                    num_hashes,
-                    alloc_bytes as f64 / (1024.0 * 1024.0)
-                ).into(),
-            );
-        }
-        let mut hashes = Vec::with_capacity(num_hashes);
-        #[cfg(target_arch = "wasm32")]
-        web_sys::console::log_1(
-            &format!("  {} section: Vec allocated, starting decode loop", section.label).into(),
-        );
-        for (hash_idx, chunk) in words_slice[start..end].chunks(WORDS_PER_DIGEST).enumerate() {
-            match words_to_hash::<F>(chunk) {
-                Ok(h) => hashes.push(h),
-                Err(e) => {
-                    #[cfg(target_arch = "wasm32")]
-                    web_sys::console::error_1(
-                        &format!(
-                            "ERROR decoding {} section hash #{}/{}: {:?}, raw words: {:?}",
-                            section.label, hash_idx, num_hashes, e,
-                            &chunk[..chunk.len().min(8)]
-                        )
-                        .into(),
-                    );
-                    return Err(e);
-                }
-            }
-            if hash_idx % 10000 == 0 {
-                #[cfg(target_arch = "wasm32")]
-                web_sys::console::log_1(
-                    &format!("  {} section: decoded {}/{} hashes", section.label, hash_idx, num_hashes).into(),
-                );
-            }
-        }
-        let convert_ms = now_ms() - convert_start;
-        let readback_ms = copy_elapsed * (section.word_len as f64) / total_words_f;
-        results.push(HashSectionResult {
-            hashes,
-            readback_ms,
-            convert_ms,
-        });
-    }
-    drop(data);
-    staging.unmap();
-    yield_to_event_loop().await;
-
-    Ok(results)
 }
 
 fn send_chunk_data<F: RichField>(ctx: &MerkleTreeGpuContext, leaves: &[Vec<F>]) -> Buffer {

--- a/plonky2/src/hash/merkle_tree_gpu.rs
+++ b/plonky2/src/hash/merkle_tree_gpu.rs
@@ -38,7 +38,7 @@ const ROUND_CONSTANT_COUNT: usize = POSEIDON_WIDTH * poseidon::N_ROUNDS;
 
 // for `now` for timing
 use js_sys::Promise;
-use wasm_bindgen::prelude::*;
+use wasm_bindgen::{prelude::*, JsCast};
 use wasm_bindgen_futures::JsFuture;
 
 thread_local! {
@@ -169,6 +169,17 @@ fn field_to_words<F: RichField>(value: &F) -> [u32; BIGINT_LIMBS] {
 
 fn words_to_field<F: RichField>(words: &[u32; BIGINT_LIMBS]) -> F {
     let canon = (words[1] as u64) << 32 | (words[0] as u64);
+    // Goldilocks modulus: 2^64 - 2^32 + 1 = 18446744069414584321
+    if canon >= 18446744069414584321u64 {
+        #[cfg(target_arch = "wasm32")]
+        web_sys::console::error_1(
+            &format!(
+                "ERROR: non-canonical value from GPU: {} (words: [{:#010x}, {:#010x}])",
+                canon, words[0], words[1]
+            )
+            .into(),
+        );
+    }
     F::from_canonical_u64(canon)
 }
 
@@ -935,6 +946,15 @@ where
                 wait_for_queue(queue_completion).await?;
                 log_timing("⚡ GPU execution (wait_for_queue)", now_ms() - wait_start);
 
+                #[cfg(target_arch = "wasm32")]
+                web_sys::console::log_1(
+                    &format!(
+                        "GPU done. Tree info: num_leaves={}, total_nodes={}, cap_len={}, cap_height={}",
+                        num_leaves, total_nodes, cap_len, cap_height
+                    )
+                    .into(),
+                );
+
                 let mut sections = Vec::with_capacity(3);
                 sections.push(HashSection {
                     label: "Leaf",
@@ -1120,7 +1140,16 @@ async fn read_hash_sections<F: RichField>(
         .iter()
         .map(|section| (section.word_len * std::mem::size_of::<u32>()) as u64)
         .sum();
+
+    #[cfg(target_arch = "wasm32")]
+    web_sys::console::log_1(
+        &format!("read_hash_sections: total_bytes={}, getting staging buffer", total_bytes).into(),
+    );
+
     let staging = context.get_or_make_staging(total_bytes);
+
+    #[cfg(target_arch = "wasm32")]
+    web_sys::console::log_1(&"read_hash_sections: staging buffer acquired, encoding copies".into());
 
     context
         .device
@@ -1142,6 +1171,9 @@ async fn read_hash_sections<F: RichField>(
     let submission_index = context.queue.submit(Some(encoder.finish()));
     log_queue_submission("combined_readback_copy", submission_index);
 
+    #[cfg(target_arch = "wasm32")]
+    web_sys::console::log_1(&"read_hash_sections: copies submitted, starting map_async".into());
+
     let slice = staging.slice(0..total_bytes);
     let (map_tx, map_rx) = oneshot::channel();
     let readback_id = READBACK_SEQ.fetch_add(1, Ordering::Relaxed);
@@ -1159,11 +1191,19 @@ async fn read_hash_sections<F: RichField>(
         .map_err(|err| anyhow!("{label} map_async error: {err:?}"))?;
     let copy_elapsed = now_ms() - copy_start;
 
+    #[cfg(target_arch = "wasm32")]
+    web_sys::console::log_1(
+        &format!("read_hash_sections: map_async completed in {:.2}ms", copy_elapsed).into(),
+    );
+
     if let Some(err) =
         pop_error_scope(context.device.clone(), format!("{label} validation scope")).await
     {
         return Err(anyhow!("validation error during readback: {err:?}"));
     }
+
+    #[cfg(target_arch = "wasm32")]
+    web_sys::console::log_1(&"read_hash_sections: no validation errors, reading mapped range".into());
 
     let data = slice.get_mapped_range();
     let words_slice: &[u32] = bytemuck::cast_slice::<u8, u32>(&data);
@@ -1172,16 +1212,79 @@ async fn read_hash_sections<F: RichField>(
     for (idx, section) in sections.iter().enumerate() {
         let start = offsets_words[idx];
         let end = start + section.word_len;
-        debug_assert!(
-            end <= words_slice.len(),
-            "{label} mapped words shorter than expected for {} section",
-            section.label
+        #[cfg(target_arch = "wasm32")]
+        web_sys::console::log_1(
+            &format!(
+                "Decoding {} section: {} words ({} hashes), slice range [{}..{}], total buffer words: {}",
+                section.label,
+                section.word_len,
+                section.word_len / WORDS_PER_DIGEST,
+                start,
+                end,
+                words_slice.len()
+            )
+            .into(),
         );
+        if end > words_slice.len() {
+            return Err(anyhow!(
+                "{} section out of bounds: need [{}..{}] but buffer only has {} words",
+                section.label,
+                start,
+                end,
+                words_slice.len()
+            ));
+        }
         let convert_start = now_ms();
-        let hashes = words_slice[start..end]
-            .chunks(WORDS_PER_DIGEST)
-            .map(words_to_hash::<F>)
-            .collect::<Result<Vec<_>>>()?;
+        let num_hashes = section.word_len / WORDS_PER_DIGEST;
+        #[cfg(target_arch = "wasm32")]
+        {
+            let mem = wasm_bindgen::memory().dyn_into::<js_sys::WebAssembly::Memory>().unwrap();
+            let buf = mem.buffer();
+            let buf_size = if let Ok(ab) = buf.dyn_into::<js_sys::ArrayBuffer>() {
+                ab.byte_length()
+            } else {
+                let sab = mem.buffer().dyn_into::<js_sys::SharedArrayBuffer>().unwrap();
+                sab.byte_length()
+            };
+            let alloc_bytes = num_hashes * std::mem::size_of::<HashOut<F>>();
+            web_sys::console::log_1(
+                &format!(
+                    "  {} section: WASM memory={:.1}MB, allocating Vec for {} hashes ({:.1}MB)",
+                    section.label,
+                    buf_size as f64 / (1024.0 * 1024.0),
+                    num_hashes,
+                    alloc_bytes as f64 / (1024.0 * 1024.0)
+                ).into(),
+            );
+        }
+        let mut hashes = Vec::with_capacity(num_hashes);
+        #[cfg(target_arch = "wasm32")]
+        web_sys::console::log_1(
+            &format!("  {} section: Vec allocated, starting decode loop", section.label).into(),
+        );
+        for (hash_idx, chunk) in words_slice[start..end].chunks(WORDS_PER_DIGEST).enumerate() {
+            match words_to_hash::<F>(chunk) {
+                Ok(h) => hashes.push(h),
+                Err(e) => {
+                    #[cfg(target_arch = "wasm32")]
+                    web_sys::console::error_1(
+                        &format!(
+                            "ERROR decoding {} section hash #{}/{}: {:?}, raw words: {:?}",
+                            section.label, hash_idx, num_hashes, e,
+                            &chunk[..chunk.len().min(8)]
+                        )
+                        .into(),
+                    );
+                    return Err(e);
+                }
+            }
+            if hash_idx % 10000 == 0 {
+                #[cfg(target_arch = "wasm32")]
+                web_sys::console::log_1(
+                    &format!("  {} section: decoded {}/{} hashes", section.label, hash_idx, num_hashes).into(),
+                );
+            }
+        }
         let convert_ms = now_ms() - convert_start;
         let readback_ms = copy_elapsed * (section.word_len as f64) / total_words_f;
         results.push(HashSectionResult {

--- a/plonky2/src/hash/merkle_tree_gpu.rs
+++ b/plonky2/src/hash/merkle_tree_gpu.rs
@@ -1010,7 +1010,6 @@ where
                     let accessor = RawLayerAccessor::new(
                         words_slice,
                         leaf_words,
-                        node_words,
                         &cap_hashes,
                         num_leaves,
                         num_layers_to_cap,
@@ -1914,7 +1913,6 @@ impl<'a, F: RichField> RawLayerAccessor<'a, F> {
     fn new(
         words: &'a [u32],
         leaf_words_len: usize,
-        _node_words_len: usize,
         cap_hashes: &'a [HashOut<F>],
         num_leaves: usize,
         num_layers_to_cap: usize,

--- a/plonky2/src/hash/merkle_tree_gpu.rs
+++ b/plonky2/src/hash/merkle_tree_gpu.rs
@@ -952,20 +952,33 @@ where
                     .device
                     .push_error_scope(wgpu::ErrorFilter::Validation);
 
-                let mut encoder = context
-                    .device
-                    .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                        label: Some("merkle-combined-readback"),
-                    });
+                let mut encoder =
+                    context
+                        .device
+                        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                            label: Some("merkle-combined-readback"),
+                        });
                 let mut offset_bytes = 0u64;
                 // Leaf
                 let leaf_bytes = (leaf_words * std::mem::size_of::<u32>()) as u64;
-                encoder.copy_buffer_to_buffer(&buffers.input, 0, &staging, offset_bytes, leaf_bytes);
+                encoder.copy_buffer_to_buffer(
+                    &buffers.input,
+                    0,
+                    &staging,
+                    offset_bytes,
+                    leaf_bytes,
+                );
                 offset_bytes += leaf_bytes;
                 // Node
                 if total_nodes > 0 {
                     let node_bytes = (node_words * std::mem::size_of::<u32>()) as u64;
-                    encoder.copy_buffer_to_buffer(&buffers.nodes, 0, &staging, offset_bytes, node_bytes);
+                    encoder.copy_buffer_to_buffer(
+                        &buffers.nodes,
+                        0,
+                        &staging,
+                        offset_bytes,
+                        node_bytes,
+                    );
                     offset_bytes += node_bytes;
                 }
                 // Cap
@@ -1594,10 +1607,12 @@ where
     log_timing_verbose("Buffer allocation", now_ms() - buffer_start);
 
     // PHASE 3: Layer processing
-    log_lazy(|| format!(
-        "=== PHASE 3: Layer Processing ({} layers) ===",
-        num_layers_to_cap
-    ));
+    log_lazy(|| {
+        format!(
+            "=== PHASE 3: Layer Processing ({} layers) ===",
+            num_layers_to_cap
+        )
+    });
     let layer_setup_start = now_ms();
 
     for layer in 0..num_layers_to_cap {
@@ -1885,7 +1900,6 @@ impl<'a, F: RichField> LayerAccessor<'a, F> {
             num_layers_to_cap,
         }
     }
-
 }
 
 impl<'a, F: RichField> MerkleLayerAccess<F> for LayerAccessor<'a, F> {

--- a/plonky2/src/hash/merkle_tree_gpu.rs
+++ b/plonky2/src/hash/merkle_tree_gpu.rs
@@ -315,6 +315,10 @@ pub async fn initialize() -> Result<()> {
 
     log("Requesting adapter");
 
+    // Per Amendment A2: replace `.expect("failed to obtain WebGPU adapter")`
+    // with proper Result propagation. The original `expect` panicked, which on
+    // wasm32 surfaces as an unhandled JS exception and gives no opportunity for
+    // callers (e.g. `try_build_merkle_tree`) to fall back to the CPU path.
     let adapter = instance
         .request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
@@ -322,8 +326,7 @@ pub async fn initialize() -> Result<()> {
             force_fallback_adapter: false,
         })
         .await
-        .expect("failed to obtain WebGPU adapter");
-    //.ok_or_else(|| anyhow!("failed to obtain WebGPU adapter"))?;
+        .map_err(|e| anyhow!("failed to obtain WebGPU adapter: {e:?}"))?;
 
     log("Requesting device");
 

--- a/plonky2/src/hash/merkle_tree_gpu.rs
+++ b/plonky2/src/hash/merkle_tree_gpu.rs
@@ -1027,6 +1027,10 @@ where
                             leaf_offset,
                             subtree_leaves_len,
                         );
+                        debug_assert_eq!(
+                            accessor.node(accessor.cap_layer(), subtree_idx),
+                            cap_hashes[subtree_idx]
+                        );
                     }
 
                     digests

--- a/plonky2/src/hash/mod.rs
+++ b/plonky2/src/hash/mod.rs
@@ -8,6 +8,8 @@ pub mod hashing;
 pub mod keccak;
 pub mod merkle_proofs;
 pub mod merkle_tree;
+#[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+pub mod merkle_tree_gpu;
 pub mod path_compression;
 pub mod poseidon;
 pub mod poseidon_goldilocks;

--- a/plonky2/src/iop/ext_target.rs
+++ b/plonky2/src/iop/ext_target.rs
@@ -11,66 +11,6 @@ use crate::hash::hash_types::RichField;
 use crate::iop::target::Target;
 use crate::plonk::circuit_builder::CircuitBuilder;
 
-mod arrays {
-    #[cfg(not(feature = "std"))]
-    use alloc::vec::Vec;
-    use core::convert::TryInto;
-    use core::marker::PhantomData;
-
-    use serde::de::{SeqAccess, Visitor};
-    use serde::ser::SerializeTuple;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    pub fn serialize<S: Serializer, T: Serialize, const N: usize>(
-        data: &[T; N],
-        ser: S,
-    ) -> Result<S::Ok, S::Error> {
-        let mut s = ser.serialize_tuple(N)?;
-        for item in data {
-            s.serialize_element(item)?;
-        }
-        s.end()
-    }
-
-    struct ArrayVisitor<T, const N: usize>(PhantomData<T>);
-
-    impl<'de, T, const N: usize> Visitor<'de> for ArrayVisitor<T, N>
-    where
-        T: Deserialize<'de>,
-    {
-        type Value = [T; N];
-
-        fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
-            formatter.write_str("an array of length N")
-        }
-
-        #[inline]
-        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-        where
-            A: SeqAccess<'de>,
-        {
-            // can be optimized using MaybeUninit
-            let mut data = Vec::with_capacity(N);
-            for _ in 0..N {
-                match (seq.next_element())? {
-                    Some(val) => data.push(val),
-                    None => return Err(serde::de::Error::invalid_length(N, &self)),
-                }
-            }
-            match data.try_into() {
-                Ok(arr) => Ok(arr),
-                Err(_) => unreachable!(),
-            }
-        }
-    }
-    pub fn deserialize<'de, D, T, const N: usize>(deserializer: D) -> Result<[T; N], D::Error>
-    where
-        D: Deserializer<'de>,
-        T: Deserialize<'de>,
-    {
-        deserializer.deserialize_tuple(N, ArrayVisitor::<T, N>(PhantomData))
-    }
-}
-
 /// `Target`s representing an element of an extension field.
 ///
 /// This is typically used in recursion settings, where the outer circuit must verify

--- a/plonky2/src/iop/ext_target.rs
+++ b/plonky2/src/iop/ext_target.rs
@@ -76,9 +76,8 @@ mod arrays {
 /// This is typically used in recursion settings, where the outer circuit must verify
 /// a proof satisfying an inner circuit's statement, which is verified using arithmetic
 /// in an extension of the base field.
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Serialize, Deserialize)]
-#[serde(bound = "")]
-pub struct ExtensionTarget<const D: usize>(#[serde(with = "arrays")] pub [Target; D]);
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct ExtensionTarget<const D: usize>(pub [Target; D]);
 
 impl<const D: usize> Serialize for ExtensionTarget<D> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {

--- a/plonky2/src/iop/ext_target.rs
+++ b/plonky2/src/iop/ext_target.rs
@@ -80,6 +80,22 @@ mod arrays {
 #[serde(bound = "")]
 pub struct ExtensionTarget<const D: usize>(#[serde(with = "arrays")] pub [Target; D]);
 
+impl<const D: usize> Serialize for ExtensionTarget<D> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.as_slice().serialize(serializer)
+    }
+}
+
+impl<'de, const D: usize> Deserialize<'de> for ExtensionTarget<D> {
+    fn deserialize<De: serde::Deserializer<'de>>(deserializer: De) -> Result<Self, De::Error> {
+        let v = Vec::<Target>::deserialize(deserializer)?;
+        let arr: [Target; D] = v
+            .try_into()
+            .map_err(|_| serde::de::Error::custom("wrong array length"))?;
+        Ok(Self(arr))
+    }
+}
+
 impl<const D: usize> Default for ExtensionTarget<D> {
     fn default() -> Self {
         Self([Target::default(); D])

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -1509,6 +1509,11 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         let max_fft_points = 1 << (degree_bits + max(rate_bits, log2_ceil(quotient_degree_factor)));
         let fft_root_table = fft_root_table(max_fft_points);
 
+        // Preserve raw constant evaluations (transposed to row-major) before
+        // they are consumed by the FRI commitment. These are needed by
+        // alternative proving backends (e.g., multilinear).
+        let constant_evals = transpose_poly_values(constant_vecs.clone());
+
         let constants_sigmas_commitment = if commit_to_sigma {
             let constants_sigmas_vecs = [constant_vecs, sigma_vecs.clone()].concat();
             with_timer_async("circuit_builder::commit constants+sigmas", || async {
@@ -1631,6 +1636,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             generator_indices_by_watches,
             constants_sigmas_commitment,
             sigmas: transpose_poly_values(sigma_vecs),
+            constant_evals,
             subgroup,
             public_inputs: self.public_inputs,
             representative_map: forest.parents,

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -50,6 +50,7 @@ use crate::plonk::copy_constraint::CopyConstraint;
 use crate::plonk::permutation_argument::Forest;
 use crate::plonk::plonk_common::PlonkOracle;
 use crate::timed;
+use crate::util::profiling::{with_timer, with_timer_async};
 use crate::util::builder_hook::BuilderHookRef;
 use crate::util::context_tree::ContextTree;
 use crate::util::partial_products::num_partial_products;
@@ -1097,13 +1098,15 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         let start = Instant::now();
 
         // Execute all hooks
-        let hooks = take(&mut self.hooks);
-        let mut hook_keys = hooks.keys().cloned().collect::<Vec<_>>();
-        hook_keys.sort(); // Sort the keys to ensure deterministic order.
-        for key in hook_keys {
-            let hook = hooks.get(&key).unwrap();
-            hook.0.constrain(&mut self);
-        }
+        with_timer("circuit_builder::execute hooks", || {
+            let hooks = take(&mut self.hooks);
+            let mut hook_keys = hooks.keys().cloned().collect::<Vec<_>>();
+            hook_keys.sort(); // Sort the keys to ensure deterministic order.
+            for key in hook_keys {
+                let hook = hooks.get(&key).unwrap();
+                hook.0.constrain(&mut self);
+            }
+        });
 
         let rate_bits = self.config.fri_config.rate_bits;
         let cap_height = self.config.fri_config.cap_height;
@@ -1125,7 +1128,9 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         self.randomize_unused_pi_wires(pi_gate);
 
         // Place LUT-related gates.
-        self.add_all_lookups();
+        with_timer("circuit_builder::add lookups", || {
+            self.add_all_lookups();
+        });
 
         // Make sure we have enough constant generators. If not, add a `ConstantGate`.
         while self.constants_to_targets.len() > self.constant_generators.len() {
@@ -1160,7 +1165,9 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             "Degree before blinding & padding: {}",
             self.gate_instances.len()
         );
-        self.blind_and_pad();
+        with_timer("circuit_builder::blind_and_pad", || {
+            self.blind_and_pad();
+        });
         let degree = self.gate_instances.len();
         debug!("Degree after blinding & padding: {}", degree);
         let degree_bits = log2_strict(degree);
@@ -1174,33 +1181,45 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         let mut gates = self.gates.iter().cloned().collect::<Vec<_>>();
         // Gates need to be sorted by their degrees (and ID to make the ordering deterministic) to compute the selector polynomials.
         gates.sort_unstable_by_key(|g| (g.0.degree(), g.0.id()));
-        let (mut constant_vecs, selectors_info) =
-            selector_polynomials(&gates, &self.gate_instances, quotient_degree_factor + 1);
+        let (mut constant_vecs, selectors_info) = with_timer(
+            "circuit_builder::selector polynomials",
+            || selector_polynomials(&gates, &self.gate_instances, quotient_degree_factor + 1),
+        );
 
         // Get the lookup selectors.
         let num_lookup_selectors = if num_luts != 0 {
-            let selector_lookups =
-                selectors_lookup(&gates, &self.gate_instances, &self.lookup_rows);
-            let selector_ends = selector_ends_lookups(&self.lookup_rows, &self.gate_instances);
-            let all_lookup_selectors = [selector_lookups, selector_ends].concat();
-            let num_lookup_selectors = all_lookup_selectors.len();
+            let (all_lookup_selectors, num_lookup_selectors) =
+                with_timer("circuit_builder::lookup selectors", || {
+                    let selector_lookups =
+                        selectors_lookup(&gates, &self.gate_instances, &self.lookup_rows);
+                    let selector_ends =
+                        selector_ends_lookups(&self.lookup_rows, &self.gate_instances);
+                    let all_lookup_selectors = [selector_lookups, selector_ends].concat();
+                    let num_lookup_selectors = all_lookup_selectors.len();
+                    (all_lookup_selectors, num_lookup_selectors)
+                });
             constant_vecs.extend(all_lookup_selectors);
             num_lookup_selectors
         } else {
             0
         };
 
-        constant_vecs.extend(self.constant_polys());
+        let extra_constants = with_timer("circuit_builder::constant polys", || {
+            self.constant_polys()
+        });
+        constant_vecs.extend(extra_constants);
         let num_constants = constant_vecs.len();
 
         let subgroup = F::two_adic_subgroup(degree_bits);
 
         let k_is = get_unique_coset_shifts(degree, self.config.num_routed_wires);
-        let (sigma_vecs, forest) = timed!(
-            timing,
-            "generate sigma polynomials",
-            self.sigma_vecs(&k_is, &subgroup)
-        );
+        let (sigma_vecs, forest) = with_timer("circuit_builder::sigma polynomials", || {
+            timed!(
+                timing,
+                "generate sigma polynomials",
+                self.sigma_vecs(&k_is, &subgroup)
+            )
+        });
 
         // Precompute FFT roots.
         let max_fft_points = 1 << (degree_bits + max(rate_bits, log2_ceil(quotient_degree_factor)));
@@ -1233,20 +1252,22 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             .collect::<HashMap<_, _>>();
 
         // Add gate generators.
-        self.add_generators(
-            self.gate_instances
-                .iter()
-                .enumerate()
-                .flat_map(|(index, gate)| {
-                    let mut gens = gate.gate_ref.0.generators(index, &gate.constants);
-                    // Remove unused generators, if any.
-                    if let Some(&op) = incomplete_gates.get(&index) {
-                        gens.drain(op..);
-                    }
-                    gens
-                })
-                .collect(),
-        );
+        with_timer("circuit_builder::add generators", || {
+            self.add_generators(
+                self.gate_instances
+                    .iter()
+                    .enumerate()
+                    .flat_map(|(index, gate)| {
+                        let mut gens = gate.gate_ref.0.generators(index, &gate.constants);
+                        // Remove unused generators, if any.
+                        if let Some(&op) = incomplete_gates.get(&index) {
+                            gens.drain(op..);
+                        }
+                        gens
+                    })
+                    .collect(),
+            );
+        });
 
         // Index generator indices by their watched targets.
         let mut generator_indices_by_watches = BTreeMap::new();
@@ -1351,6 +1372,331 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             },
             success,
         )
+    }
+
+    #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+    pub async fn try_build_with_options_wasm<C: GenericConfig<D, F = F>>(
+        mut self,
+        commit_to_sigma: bool,
+    ) -> (CircuitData<F, C, D>, bool) {
+        #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+        let timing_level = Level::Info;
+        #[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
+        let timing_level = Level::Trace;
+        let mut timing = TimingTree::new("preprocess", timing_level);
+
+        // Execute all hooks
+        with_timer("circuit_builder::execute hooks", || {
+            let hooks = take(&mut self.hooks);
+            let mut hook_keys = hooks.keys().cloned().collect::<Vec<_>>();
+            hook_keys.sort(); // Sort the keys to ensure deterministic order.
+            for key in hook_keys {
+                let hook = hooks.get(&key).unwrap();
+                hook.0.constrain(&mut self);
+            }
+        });
+
+        let rate_bits = self.config.fri_config.rate_bits;
+        let cap_height = self.config.fri_config.cap_height;
+        // Total number of LUTs.
+        let num_luts = self.get_luts_length();
+        // Hash the public inputs, and route them to a `PublicInputGate` which will enforce that
+        // those hash wires match the claimed public inputs.
+        let (num_public_inputs, pi_gate) =
+            with_timer("circuit_builder::public inputs", || {
+                let num_public_inputs = self.public_inputs.len();
+                let public_inputs_hash =
+                    self.hash_n_to_hash_no_pad::<C::InnerHasher>(self.public_inputs.clone());
+                let pi_gate = self.add_gate(PublicInputGate, vec![]);
+                for (&hash_part, wire) in public_inputs_hash
+                    .elements
+                    .iter()
+                    .zip(PublicInputGate::wires_public_inputs_hash())
+                {
+                    self.connect(hash_part, Target::wire(pi_gate, wire))
+                }
+                (num_public_inputs, pi_gate)
+            });
+        self.randomize_unused_pi_wires(pi_gate);
+
+        // Place LUT-related gates.
+        with_timer("circuit_builder::add lookups", || {
+            self.add_all_lookups();
+        });
+
+        // Make sure we have enough constant generators. If not, add a `ConstantGate`.
+        with_timer("circuit_builder::pad constant gates", || {
+            while self.constants_to_targets.len() > self.constant_generators.len() {
+                self.add_gate(
+                    ConstantGate {
+                        num_consts: self.config.num_constants,
+                    },
+                    vec![],
+                );
+            }
+        });
+
+        // For each constant-target pair used in the circuit, use a constant generator to fill this target.
+        with_timer("circuit_builder::assign constant generators", || {
+            for ((c, t), mut const_gen) in self
+                .constants_to_targets
+                .clone()
+                .into_iter()
+                // We need to enumerate constants_to_targets in some deterministic order to ensure that
+                // building a circuit is deterministic.
+                .sorted_by_key(|(c, _t)| c.to_canonical_u64())
+                .zip(self.constant_generators.clone())
+            {
+                // Set the constant in the constant polynomial.
+                self.gate_instances[const_gen.row].constants[const_gen.constant_index] = c;
+                // Generate a copy between the target and the routable wire.
+                self.connect(Target::wire(const_gen.row, const_gen.wire_index), t);
+                // Set the constant in the generator (it's initially set with a dummy value).
+                const_gen.set_constant(c);
+                self.add_simple_generator(const_gen);
+            }
+        });
+
+        debug!(
+            "Degree before blinding & padding: {}",
+            self.gate_instances.len()
+        );
+        with_timer("circuit_builder::blind_and_pad", || {
+            self.blind_and_pad();
+        });
+        let degree = self.gate_instances.len();
+        debug!("Degree after blinding & padding: {}", degree);
+        let degree_bits = log2_strict(degree);
+        let fri_params = self.fri_params(degree_bits);
+        assert!(
+            fri_params.total_arities() <= degree_bits + rate_bits - cap_height,
+            "FRI total reduction arity is too large.",
+        );
+
+        let quotient_degree_factor = self.config.max_quotient_degree_factor;
+        let mut gates = self.gates.iter().cloned().collect::<Vec<_>>();
+        // Gates need to be sorted by their degrees (and ID to make the ordering deterministic) to compute the selector polynomials.
+        gates.sort_unstable_by_key(|g| (g.0.degree(), g.0.id()));
+        let (mut constant_vecs, selectors_info) =
+            selector_polynomials(&gates, &self.gate_instances, quotient_degree_factor + 1);
+
+        // Get the lookup selectors.
+        let num_lookup_selectors = if num_luts != 0 {
+            let selector_lookups =
+                selectors_lookup(&gates, &self.gate_instances, &self.lookup_rows);
+            let selector_ends = selector_ends_lookups(&self.lookup_rows, &self.gate_instances);
+            let all_lookup_selectors = [selector_lookups, selector_ends].concat();
+            let num_lookup_selectors = all_lookup_selectors.len();
+            constant_vecs.extend(all_lookup_selectors);
+            num_lookup_selectors
+        } else {
+            0
+        };
+
+        constant_vecs.extend(self.constant_polys());
+        let num_constants = constant_vecs.len();
+
+        let subgroup = F::two_adic_subgroup(degree_bits);
+
+        let k_is = get_unique_coset_shifts(degree, self.config.num_routed_wires);
+        let (sigma_vecs, forest) = timed!(
+            timing,
+            "generate sigma polynomials",
+            self.sigma_vecs(&k_is, &subgroup)
+        );
+
+        // Precompute FFT roots.
+        let max_fft_points = 1 << (degree_bits + max(rate_bits, log2_ceil(quotient_degree_factor)));
+        let fft_root_table = fft_root_table(max_fft_points);
+
+        let constants_sigmas_commitment = if commit_to_sigma {
+            let constants_sigmas_vecs = [constant_vecs, sigma_vecs.clone()].concat();
+            with_timer_async("circuit_builder::commit constants+sigmas", || async {
+                PolynomialBatch::<F, C, D>::from_values_async(
+                    constants_sigmas_vecs,
+                    rate_bits,
+                    PlonkOracle::CONSTANTS_SIGMAS.blinding,
+                    cap_height,
+                    &mut timing,
+                    Some(&fft_root_table),
+                )
+                .await
+            })
+            .await
+        } else {
+            PolynomialBatch::<F, C, D>::default()
+        };
+
+        // Map between gates where not all generators are used and the gate's number of used generators.
+        let incomplete_gates = self
+            .current_slots
+            .values()
+            .flat_map(|current_slot| current_slot.current_slot.values().copied())
+            .collect::<HashMap<_, _>>();
+
+        // Add gate generators.
+        with_timer("circuit_builder::add generators", || {
+            self.add_generators(
+                self.gate_instances
+                    .iter()
+                    .enumerate()
+                    .flat_map(|(index, gate)| {
+                        let mut gens = gate.gate_ref.0.generators(index, &gate.constants);
+                        // Remove unused generators, if any.
+                        if let Some(&op) = incomplete_gates.get(&index) {
+                            gens.drain(op..);
+                        }
+                        gens
+                    })
+                    .collect(),
+            );
+        });
+
+        // Index generator indices by their watched targets.
+        let mut generator_indices_by_watches = BTreeMap::new();
+        with_timer("circuit_builder::index generators", || {
+            for (i, generator) in self.generators.iter().enumerate() {
+                for watch in generator.0.watch_list() {
+                    let watch_index = forest.target_index(watch);
+                    let watch_rep_index = forest.parents[watch_index];
+                    generator_indices_by_watches
+                        .entry(watch_rep_index)
+                        .or_insert_with(Vec::new)
+                        .push(i);
+                }
+            }
+            for indices in generator_indices_by_watches.values_mut() {
+                indices.dedup();
+                indices.shrink_to_fit();
+            }
+        });
+
+        let num_gate_constraints = gates
+            .iter()
+            .map(|gate| gate.0.num_constraints())
+            .max()
+            .expect("No gates?");
+
+        let num_partial_products =
+            num_partial_products(self.config.num_routed_wires, quotient_degree_factor);
+
+        let lookup_degree = self.config.max_quotient_degree_factor - 1;
+        let num_lookup_polys = if num_luts == 0 {
+            0
+        } else {
+            // There is 1 RE polynomial and multiple Sum/LDC polynomials.
+            LookupGate::num_slots(&self.config).div_ceil(lookup_degree) + 1
+        };
+        let constants_sigmas_cap = constants_sigmas_commitment.merkle_tree.cap.clone();
+        let domain_separator = self.domain_separator.unwrap_or_default();
+        let domain_separator_digest = C::Hasher::hash_pad(&domain_separator);
+        // TODO: This should also include an encoding of gate constraints.
+        let circuit_digest_parts = [
+            constants_sigmas_cap.flatten(),
+            domain_separator_digest.to_vec(),
+            vec![
+                F::from_canonical_usize(degree_bits),
+                /* Add other circuit data here */
+            ],
+        ];
+        let circuit_digest = C::Hasher::hash_no_pad(&circuit_digest_parts.concat());
+
+        let common = CommonCircuitData {
+            config: self.config,
+            fri_params,
+            gates,
+            selectors_info,
+            quotient_degree_factor,
+            num_gate_constraints,
+            num_constants,
+            num_public_inputs,
+            k_is,
+            num_partial_products,
+            num_lookup_polys,
+            num_lookup_selectors,
+            luts: self.luts,
+        };
+
+        let mut success = true;
+
+        if let Some(goal_data) = self.goal_common_data {
+            if goal_data != common {
+                warn!("The expected circuit data passed to cyclic recursion method did not match the actual circuit");
+                success = false;
+            }
+        }
+
+        let prover_only = ProverOnlyCircuitData::<F, C, D> {
+            generators: self.generators,
+            generator_indices_by_watches,
+            constants_sigmas_commitment,
+            sigmas: transpose_poly_values(sigma_vecs),
+            subgroup,
+            public_inputs: self.public_inputs,
+            representative_map: forest.parents,
+            fft_root_table: Some(fft_root_table),
+            circuit_digest,
+            lookup_rows: self.lookup_rows.clone(),
+            lut_to_lookups: self.lut_to_lookups.clone(),
+        };
+
+        let verifier_only = VerifierOnlyCircuitData::<C, D> {
+            constants_sigmas_cap,
+            circuit_digest,
+        };
+
+        timing.print();
+        (
+            CircuitData {
+                prover_only,
+                verifier_only,
+                common,
+            },
+            success,
+        )
+    }
+
+    pub async fn try_build_with_options_async<C: GenericConfig<D, F = F>>(
+        self,
+        commit_to_sigma: bool,
+    ) -> (CircuitData<F, C, D>, bool) {
+        #[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
+        {
+            return self.try_build_with_options::<C>(commit_to_sigma);
+        }
+
+        #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+        self.try_build_with_options_wasm::<C>(commit_to_sigma).await
+    }
+
+    pub async fn build_with_options_async<C: GenericConfig<D, F = F>>(
+        self,
+        commit_to_sigma: bool,
+    ) -> CircuitData<F, C, D> {
+        #[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
+        {
+            return self.build_with_options::<C>(commit_to_sigma);
+        }
+
+        #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+        {
+            let (circuit_data, success) =
+                self.try_build_with_options_wasm::<C>(commit_to_sigma).await;
+            if !success {
+                panic!("Failed to build circuit");
+            }
+            circuit_data
+        }
+    }
+
+    pub async fn build_async<C: GenericConfig<D, F = F>>(self) -> CircuitData<F, C, D> {
+        #[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
+        {
+            return self.build::<C>();
+        }
+
+        #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+        self.build_with_options_async::<C>(true).await
     }
 
     /// Builds a "full circuit", with both prover and verifier data.

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -50,10 +50,10 @@ use crate::plonk::copy_constraint::CopyConstraint;
 use crate::plonk::permutation_argument::Forest;
 use crate::plonk::plonk_common::PlonkOracle;
 use crate::timed;
-use crate::util::profiling::{with_timer, with_timer_async};
 use crate::util::builder_hook::BuilderHookRef;
 use crate::util::context_tree::ContextTree;
 use crate::util::partial_products::num_partial_products;
+use crate::util::profiling::{with_timer, with_timer_async};
 use crate::util::timing::TimingTree;
 use crate::util::{log2_ceil, log2_strict, transpose, transpose_poly_values};
 
@@ -1181,10 +1181,10 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         let mut gates = self.gates.iter().cloned().collect::<Vec<_>>();
         // Gates need to be sorted by their degrees (and ID to make the ordering deterministic) to compute the selector polynomials.
         gates.sort_unstable_by_key(|g| (g.0.degree(), g.0.id()));
-        let (mut constant_vecs, selectors_info) = with_timer(
-            "circuit_builder::selector polynomials",
-            || selector_polynomials(&gates, &self.gate_instances, quotient_degree_factor + 1),
-        );
+        let (mut constant_vecs, selectors_info) =
+            with_timer("circuit_builder::selector polynomials", || {
+                selector_polynomials(&gates, &self.gate_instances, quotient_degree_factor + 1)
+            });
 
         // Get the lookup selectors.
         let num_lookup_selectors = if num_luts != 0 {
@@ -1204,9 +1204,8 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             0
         };
 
-        let extra_constants = with_timer("circuit_builder::constant polys", || {
-            self.constant_polys()
-        });
+        let extra_constants =
+            with_timer("circuit_builder::constant polys", || self.constant_polys());
         constant_vecs.extend(extra_constants);
         let num_constants = constant_vecs.len();
 
@@ -1402,21 +1401,20 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         let num_luts = self.get_luts_length();
         // Hash the public inputs, and route them to a `PublicInputGate` which will enforce that
         // those hash wires match the claimed public inputs.
-        let (num_public_inputs, pi_gate) =
-            with_timer("circuit_builder::public inputs", || {
-                let num_public_inputs = self.public_inputs.len();
-                let public_inputs_hash =
-                    self.hash_n_to_hash_no_pad::<C::InnerHasher>(self.public_inputs.clone());
-                let pi_gate = self.add_gate(PublicInputGate, vec![]);
-                for (&hash_part, wire) in public_inputs_hash
-                    .elements
-                    .iter()
-                    .zip(PublicInputGate::wires_public_inputs_hash())
-                {
-                    self.connect(hash_part, Target::wire(pi_gate, wire))
-                }
-                (num_public_inputs, pi_gate)
-            });
+        let (num_public_inputs, pi_gate) = with_timer("circuit_builder::public inputs", || {
+            let num_public_inputs = self.public_inputs.len();
+            let public_inputs_hash =
+                self.hash_n_to_hash_no_pad::<C::InnerHasher>(self.public_inputs.clone());
+            let pi_gate = self.add_gate(PublicInputGate, vec![]);
+            for (&hash_part, wire) in public_inputs_hash
+                .elements
+                .iter()
+                .zip(PublicInputGate::wires_public_inputs_hash())
+            {
+                self.connect(hash_part, Target::wire(pi_gate, wire))
+            }
+            (num_public_inputs, pi_gate)
+        });
         self.randomize_unused_pi_wires(pi_gate);
 
         // Place LUT-related gates.

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -53,7 +53,9 @@ use crate::timed;
 use crate::util::builder_hook::BuilderHookRef;
 use crate::util::context_tree::ContextTree;
 use crate::util::partial_products::num_partial_products;
-use crate::util::profiling::{with_timer, with_timer_async};
+use crate::util::profiling::with_timer;
+#[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+use crate::util::profiling::with_timer_async;
 use crate::util::timing::TimingTree;
 use crate::util::{log2_ceil, log2_strict, transpose, transpose_poly_values};
 
@@ -1666,7 +1668,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     ) -> (CircuitData<F, C, D>, bool) {
         #[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
         {
-            return self.try_build_with_options::<C>(commit_to_sigma);
+            self.try_build_with_options::<C>(commit_to_sigma)
         }
 
         #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
@@ -1679,7 +1681,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     ) -> CircuitData<F, C, D> {
         #[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
         {
-            return self.build_with_options::<C>(commit_to_sigma);
+            self.build_with_options::<C>(commit_to_sigma)
         }
 
         #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
@@ -1696,7 +1698,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     pub async fn build_async<C: GenericConfig<D, F = F>>(self) -> CircuitData<F, C, D> {
         #[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
         {
-            return self.build::<C>();
+            self.build::<C>()
         }
 
         #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]

--- a/plonky2/src/plonk/circuit_data.rs
+++ b/plonky2/src/plonk/circuit_data.rs
@@ -46,7 +46,7 @@ use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::config::{GenericConfig, Hasher};
 use crate::plonk::plonk_common::PlonkOracle;
 use crate::plonk::proof::{CompressedProofWithPublicInputs, ProofWithPublicInputs};
-use crate::plonk::prover::prove;
+use crate::plonk::prover::{prove, prove_async};
 use crate::plonk::verifier::verify;
 use crate::util::serialization::{
     Buffer, GateSerializer, IoResult, Read, WitnessGeneratorSerializer, Write,
@@ -193,6 +193,19 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
             inputs,
             &mut TimingTree::default(),
         )
+    }
+
+    pub async fn prove_async(
+        &self,
+        inputs: PartialWitness<F>,
+    ) -> Result<ProofWithPublicInputs<F, C, D>> {
+        prove_async::<F, C, D>(
+            &self.prover_only,
+            &self.common,
+            inputs,
+            &mut TimingTree::default(),
+        )
+        .await
     }
 
     pub fn verify(&self, proof_with_pis: ProofWithPublicInputs<F, C, D>) -> Result<()> {

--- a/plonky2/src/plonk/proof.rs
+++ b/plonky2/src/plonk/proof.rs
@@ -626,9 +626,9 @@ mod tests {
                             },
                         }],
                     }],
-                    final_poly: crate::gadgets::polynomial::PolynomialCoeffsExtTarget(vec![
-                        ext(80),
-                    ]),
+                    final_poly: crate::gadgets::polynomial::PolynomialCoeffsExtTarget(vec![ext(
+                        80,
+                    )]),
                     pow_witness: t(90),
                 },
             },

--- a/plonky2/src/plonk/proof.rs
+++ b/plonky2/src/plonk/proof.rs
@@ -565,4 +565,77 @@ mod tests {
         verify(proof, &data.verifier_only, &data.common)?;
         data.verify_compressed(compressed_proof)
     }
+
+    #[test]
+    fn test_circuit_target_serde_round_trip() {
+        use crate::hash::hash_types::{HashOutTarget, MerkleCapTarget};
+        use crate::hash::merkle_proofs::MerkleProofTarget;
+        use crate::iop::ext_target::ExtensionTarget;
+        use crate::iop::target::Target;
+        use crate::plonk::circuit_data::VerifierCircuitTarget;
+
+        const D: usize = 2;
+
+        let t = |i| Target::VirtualTarget { index: i };
+        let ext = |i| ExtensionTarget::<D>([t(i), t(i + 1)]);
+        let hash_out = |i| HashOutTarget {
+            elements: [t(i), t(i + 1), t(i + 2), t(i + 3)],
+        };
+
+        // Test VerifierCircuitTarget round-trip.
+        let vct = VerifierCircuitTarget {
+            constants_sigmas_cap: MerkleCapTarget(vec![hash_out(0), hash_out(10)]),
+            circuit_digest: hash_out(20),
+        };
+        let json = serde_json::to_string(&vct).unwrap();
+        let vct2: VerifierCircuitTarget = serde_json::from_str(&json).unwrap();
+        assert_eq!(vct, vct2);
+
+        // Test ProofWithPublicInputsTarget round-trip.
+        let pwpit = ProofWithPublicInputsTarget::<D> {
+            proof: ProofTarget {
+                wires_cap: MerkleCapTarget(vec![hash_out(0)]),
+                plonk_zs_partial_products_cap: MerkleCapTarget(vec![hash_out(10)]),
+                quotient_polys_cap: MerkleCapTarget(vec![hash_out(20)]),
+                openings: OpeningSetTarget {
+                    constants: vec![ext(0)],
+                    plonk_sigmas: vec![ext(2)],
+                    wires: vec![ext(4)],
+                    plonk_zs: vec![ext(6)],
+                    plonk_zs_next: vec![ext(8)],
+                    lookup_zs: vec![],
+                    next_lookup_zs: vec![],
+                    partial_products: vec![ext(10)],
+                    quotient_polys: vec![ext(12)],
+                },
+                opening_proof: crate::fri::proof::FriProofTarget {
+                    commit_phase_merkle_caps: vec![MerkleCapTarget(vec![hash_out(30)])],
+                    query_round_proofs: vec![crate::fri::proof::FriQueryRoundTarget {
+                        initial_trees_proof: crate::fri::proof::FriInitialTreeProofTarget {
+                            evals_proofs: vec![(
+                                vec![t(40), t(41)],
+                                MerkleProofTarget {
+                                    siblings: vec![hash_out(50)],
+                                },
+                            )],
+                        },
+                        steps: vec![crate::fri::proof::FriQueryStepTarget {
+                            evals: vec![ext(60)],
+                            merkle_proof: MerkleProofTarget {
+                                siblings: vec![hash_out(70)],
+                            },
+                        }],
+                    }],
+                    final_poly: crate::gadgets::polynomial::PolynomialCoeffsExtTarget(vec![
+                        ext(80),
+                    ]),
+                    pow_witness: t(90),
+                },
+            },
+            public_inputs: vec![t(100), t(101)],
+        };
+        let json = serde_json::to_string(&pwpit).unwrap();
+        let pwpit2: ProofWithPublicInputsTarget<D> = serde_json::from_str(&json).unwrap();
+        assert_eq!(pwpit, pwpit2);
+    }
 }

--- a/plonky2/src/plonk/prover.rs
+++ b/plonky2/src/plonk/prover.rs
@@ -4,22 +4,21 @@
 use alloc::{format, vec, vec::Vec};
 use core::cmp::min;
 use core::mem::swap;
+#[cfg(feature = "std")]
+use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
+use std::time::Instant;
 
 use anyhow::{ensure, Result};
+use hashbrown::HashMap;
+#[cfg(all(feature = "std", target_arch = "wasm32"))]
+use js_sys::Date;
+use plonky2_maybe_rayon::*;
 #[cfg(all(
     feature = "std",
     not(all(feature = "gpu_merkle", target_arch = "wasm32"))
 ))]
 use pollster::block_on;
-use hashbrown::HashMap;
-use plonky2_maybe_rayon::*;
-
-#[cfg(feature = "std")]
-use std::sync::atomic::{AtomicU64, Ordering};
-#[cfg(all(feature = "std", target_arch = "wasm32"))]
-use js_sys::Date;
-#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
-use std::time::Instant;
 
 use super::circuit_builder::{LookupChallenges, LookupWire};
 use crate::field::extension::Extendable;
@@ -133,10 +132,7 @@ where
     C::Hasher: Hasher<F>,
     C::InnerHasher: Hasher<F>,
 {
-    let generator_label = format!(
-        "plonk/run {} generators",
-        prover_data.generators.len()
-    );
+    let generator_label = format!("plonk/run {} generators", prover_data.generators.len());
     let partition_witness = with_timer(&generator_label, || {
         timed!(
             timing,
@@ -277,17 +273,18 @@ where
         )
     });
 
-    let wires_values: Vec<PolynomialValues<F>> = with_timer("plonk/compute wire polynomials", || {
-        timed!(
-            timing,
-            "compute wire polynomials",
-            witness
-                .wire_values
-                .par_iter()
-                .map(|column| PolynomialValues::new(column.clone()))
-                .collect()
-        )
-    });
+    let wires_values: Vec<PolynomialValues<F>> =
+        with_timer("plonk/compute wire polynomials", || {
+            timed!(
+                timing,
+                "compute wire polynomials",
+                witness
+                    .wire_values
+                    .par_iter()
+                    .map(|column| PolynomialValues::new(column.clone()))
+                    .collect()
+            )
+        });
 
     let wires_commitment = with_timer_async("plonk/commit wires", || async {
         timed!(
@@ -391,9 +388,8 @@ where
         .await;
 
     #[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
-    let partial_products_zs_and_lookup_commitment = with_timer(
-        "plonk/commit partial products & Zs",
-        || {
+    let partial_products_zs_and_lookup_commitment =
+        with_timer("plonk/commit partial products & Zs", || {
             timed!(
                 timing,
                 "commit to partial products, Z's and, if any, lookup polynomials",
@@ -406,8 +402,7 @@ where
                     prover_data.fft_root_table.as_ref(),
                 )
             )
-        },
-    );
+        });
 
     challenger.observe_cap::<C::Hasher>(&partial_products_zs_and_lookup_commitment.merkle_tree.cap);
 
@@ -1211,7 +1206,9 @@ struct ProfilingInstant {
 #[cfg(all(feature = "std", target_arch = "wasm32"))]
 impl ProfilingInstant {
     fn now() -> Self {
-        Self { start_ms: Date::now() }
+        Self {
+            start_ms: Date::now(),
+        }
     }
 
     fn elapsed(&self) -> core::time::Duration {

--- a/plonky2/src/plonk/prover.rs
+++ b/plonky2/src/plonk/prover.rs
@@ -559,6 +559,13 @@ pub struct ProverPolynomials<F: RichField + Extendable<D>, const D: usize> {
 /// The standard `prove()` discards the polynomial batches after computing
 /// the FRI proof.  This function preserves them so that WHIR can commit
 /// to the same polynomials and prove evaluations at ζ.
+///
+/// SECURITY (H-2): not yet ported to the async/GPU pipeline. On
+/// `wasm32 + gpu_merkle` the underlying `prove_openings` it transitively
+/// calls is a panic stub, so this function is gated to the CPU path.
+/// Adding `prove_with_polys_async` is a follow-up; until then, callers
+/// on wasm-gpu must use one of the supported `*_async` entry points.
+#[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
 pub fn prove_with_polys<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
     prover_data: &ProverOnlyCircuitData<F, C, D>,
     common_data: &CommonCircuitData<F, D>,
@@ -578,7 +585,33 @@ where
     prove_with_partition_witness_and_polys(prover_data, common_data, partition_witness, timing)
 }
 
+/// SECURITY (H-2): explicit panic stub on `wasm32 + gpu_merkle` so that
+/// callers get a clear error at the entry point rather than a deeper
+/// panic from `fri::prover::fri_proof`. An async variant
+/// (`prove_with_polys_async`) is a planned follow-up.
+#[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+#[track_caller]
+pub fn prove_with_polys<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
+    _prover_data: &ProverOnlyCircuitData<F, C, D>,
+    _common_data: &CommonCircuitData<F, D>,
+    _inputs: PartialWitness<F>,
+    _timing: &mut TimingTree,
+) -> Result<(ProofWithPublicInputs<F, C, D>, ProverPolynomials<F, D>)>
+where
+    C::Hasher: Hasher<F>,
+    C::InnerHasher: Hasher<F>,
+{
+    panic!(
+        "plonk::prover::prove_with_polys is not yet supported on wasm with gpu_merkle enabled; \
+         no async variant has been ported"
+    );
+}
+
 /// Like `prove_with_partition_witness()`, but also returns polynomial data.
+///
+/// SECURITY (H-2): also gated on non-wasm-gpu since it transitively calls
+/// the sync `prove_openings`, which is a panic stub on wasm-gpu.
+#[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
 pub fn prove_with_partition_witness_and_polys<
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,

--- a/plonky2/src/plonk/prover.rs
+++ b/plonky2/src/plonk/prover.rs
@@ -143,7 +143,7 @@ where
             &format!("run {} generators", prover_data.generators.len()),
             generate_partial_witness(inputs, prover_data, common_data)
         )
-    });
+    })?;
 
     prove_with_partition_witness_async(prover_data, common_data, partition_witness, timing).await
 }

--- a/plonky2/src/plonk/prover.rs
+++ b/plonky2/src/plonk/prover.rs
@@ -6,8 +6,20 @@ use core::cmp::min;
 use core::mem::swap;
 
 use anyhow::{ensure, Result};
+#[cfg(all(
+    feature = "std",
+    not(all(feature = "gpu_merkle", target_arch = "wasm32"))
+))]
+use futures::executor::block_on;
 use hashbrown::HashMap;
 use plonky2_maybe_rayon::*;
+
+#[cfg(feature = "std")]
+use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(all(feature = "std", target_arch = "wasm32"))]
+use js_sys::Date;
+#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
+use std::time::Instant;
 
 use super::circuit_builder::{LookupChallenges, LookupWire};
 use crate::field::extension::Extendable;
@@ -32,6 +44,7 @@ use crate::plonk::vanishing_poly::{eval_vanishing_poly_base_batch, get_lut_poly}
 use crate::plonk::vars::EvaluationVarsBaseBatch;
 use crate::timed;
 use crate::util::partial_products::{partial_products_and_z_gx, quotient_chunk_products};
+use crate::util::profiling::{with_timer, with_timer_async};
 use crate::util::timing::TimingTree;
 use crate::util::{log2_ceil, transpose};
 
@@ -110,6 +123,32 @@ pub fn set_lookup_wires<
     Ok(())
 }
 
+pub async fn prove_async<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
+    prover_data: &ProverOnlyCircuitData<F, C, D>,
+    common_data: &CommonCircuitData<F, D>,
+    inputs: PartialWitness<F>,
+    timing: &mut TimingTree,
+) -> Result<ProofWithPublicInputs<F, C, D>>
+where
+    C::Hasher: Hasher<F>,
+    C::InnerHasher: Hasher<F>,
+{
+    let generator_label = format!(
+        "plonk/run {} generators",
+        prover_data.generators.len()
+    );
+    let partition_witness = with_timer(&generator_label, || {
+        timed!(
+            timing,
+            &format!("run {} generators", prover_data.generators.len()),
+            generate_partial_witness(inputs, prover_data, common_data)
+        )
+    });
+
+    prove_with_partition_witness_async(prover_data, common_data, partition_witness, timing).await
+}
+
+#[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
 pub fn prove<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
     prover_data: &ProverOnlyCircuitData<F, C, D>,
     common_data: &CommonCircuitData<F, D>,
@@ -127,6 +166,26 @@ where
     );
 
     prove_with_partition_witness(prover_data, common_data, partition_witness, timing)
+}
+
+#[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+#[track_caller]
+pub fn prove<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
+    _prover_data: &ProverOnlyCircuitData<F, C, D>,
+    _common_data: &CommonCircuitData<F, D>,
+    _inputs: PartialWitness<F>,
+    _timing: &mut TimingTree,
+) -> Result<ProofWithPublicInputs<F, C, D>>
+where
+    C::Hasher: Hasher<F>,
+    C::InnerHasher: Hasher<F>,
+{
+    let location = core::panic::Location::caller();
+    panic!(
+        "plonk::prover::prove must be awaited on wasm with gpu_merkle enabled; use prove_async instead (called from {}:{})",
+        location.file(),
+        location.line()
+    );
 }
 
 /// Extract raw evaluation tables from a circuit without performing polynomial
@@ -185,14 +244,14 @@ where
     })
 }
 
-pub fn prove_with_partition_witness<
+pub async fn prove_with_partition_witness_async<
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,
     const D: usize,
 >(
     prover_data: &ProverOnlyCircuitData<F, C, D>,
     common_data: &CommonCircuitData<F, D>,
-    mut partition_witness: PartitionWitness<F>,
+    mut partition_witness: PartitionWitness<'_, F>,
     timing: &mut TimingTree,
 ) -> Result<ProofWithPublicInputs<F, C, D>>
 where
@@ -210,34 +269,42 @@ where
     let public_inputs = partition_witness.get_targets(&prover_data.public_inputs);
     let public_inputs_hash = C::InnerHasher::hash_no_pad(&public_inputs);
 
-    let witness = timed!(
-        timing,
-        "compute full witness",
-        partition_witness.full_witness()
-    );
-
-    let wires_values: Vec<PolynomialValues<F>> = timed!(
-        timing,
-        "compute wire polynomials",
-        witness
-            .wire_values
-            .par_iter()
-            .map(|column| PolynomialValues::new(column.clone()))
-            .collect()
-    );
-
-    let wires_commitment = timed!(
-        timing,
-        "compute wires commitment",
-        PolynomialBatch::<F, C, D>::from_values(
-            wires_values,
-            config.fri_config.rate_bits,
-            config.zero_knowledge && PlonkOracle::WIRES.blinding,
-            config.fri_config.cap_height,
+    let witness = with_timer("plonk/compute full witness", || {
+        timed!(
             timing,
-            prover_data.fft_root_table.as_ref(),
+            "compute full witness",
+            partition_witness.full_witness()
         )
-    );
+    });
+
+    let wires_values: Vec<PolynomialValues<F>> = with_timer("plonk/compute wire polynomials", || {
+        timed!(
+            timing,
+            "compute wire polynomials",
+            witness
+                .wire_values
+                .par_iter()
+                .map(|column| PolynomialValues::new(column.clone()))
+                .collect()
+        )
+    });
+
+    let wires_commitment = with_timer_async("plonk/commit wires", || async {
+        timed!(
+            timing,
+            "compute wires commitment",
+            PolynomialBatch::<F, C, D>::from_values_async(
+                wires_values,
+                config.fri_config.rate_bits,
+                config.zero_knowledge && PlonkOracle::WIRES.blinding,
+                config.fri_config.cap_height,
+                timing,
+                prover_data.fft_root_table.as_ref(),
+            )
+            .await
+        )
+    })
+    .await;
 
     let mut challenger = Challenger::<F, C::Hasher>::new();
 
@@ -273,11 +340,19 @@ where
         common_data.quotient_degree_factor < common_data.config.num_routed_wires,
         "When the number of routed wires is smaller that the degree, we should change the logic to avoid computing partial products."
     );
-    let mut partial_products_and_zs = timed!(
-        timing,
-        "compute partial products",
-        all_wires_permutation_partial_products(&witness, &betas, &gammas, prover_data, common_data)
-    );
+    let mut partial_products_and_zs = with_timer("plonk/compute partial products", || {
+        timed!(
+            timing,
+            "compute partial products",
+            all_wires_permutation_partial_products(
+                &witness,
+                &betas,
+                &gammas,
+                prover_data,
+                common_data
+            )
+        )
+    });
 
     // Z is expected at the front of our batch; see `zs_range` and `partial_products_range`.
     let plonk_z_vecs = partial_products_and_zs
@@ -296,66 +371,100 @@ where
         zs_partial_products
     };
 
-    let partial_products_zs_and_lookup_commitment = timed!(
-        timing,
-        "commit to partial products, Z's and, if any, lookup polynomials",
-        PolynomialBatch::from_values(
-            zs_partial_products_lookups,
-            config.fri_config.rate_bits,
-            config.zero_knowledge && PlonkOracle::ZS_PARTIAL_PRODUCTS.blinding,
-            config.fri_config.cap_height,
-            timing,
-            prover_data.fft_root_table.as_ref(),
-        )
+    #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+    let partial_products_zs_and_lookup_commitment =
+        with_timer_async("plonk/commit partial products & Zs", || async {
+            timed!(
+                timing,
+                "commit to partial products, Z's and, if any, lookup polynomials",
+                PolynomialBatch::from_values_async(
+                    zs_partial_products_lookups,
+                    config.fri_config.rate_bits,
+                    config.zero_knowledge && PlonkOracle::ZS_PARTIAL_PRODUCTS.blinding,
+                    config.fri_config.cap_height,
+                    timing,
+                    prover_data.fft_root_table.as_ref(),
+                )
+                .await
+            )
+        })
+        .await;
+
+    #[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
+    let partial_products_zs_and_lookup_commitment = with_timer(
+        "plonk/commit partial products & Zs",
+        || {
+            timed!(
+                timing,
+                "commit to partial products, Z's and, if any, lookup polynomials",
+                PolynomialBatch::from_values(
+                    zs_partial_products_lookups,
+                    config.fri_config.rate_bits,
+                    config.zero_knowledge && PlonkOracle::ZS_PARTIAL_PRODUCTS.blinding,
+                    config.fri_config.cap_height,
+                    timing,
+                    prover_data.fft_root_table.as_ref(),
+                )
+            )
+        },
     );
 
     challenger.observe_cap::<C::Hasher>(&partial_products_zs_and_lookup_commitment.merkle_tree.cap);
 
     let alphas = challenger.get_n_challenges(num_challenges);
 
-    let quotient_polys = timed!(
-        timing,
-        "compute quotient polys",
-        compute_quotient_polys::<F, C, D>(
-            common_data,
-            prover_data,
-            &public_inputs_hash,
-            &wires_commitment,
-            &partial_products_zs_and_lookup_commitment,
-            &betas,
-            &gammas,
-            &deltas,
-            &alphas,
-        )
-    );
-
-    let all_quotient_poly_chunks: Vec<PolynomialCoeffs<F>> = timed!(
-        timing,
-        "split up quotient polys",
-        quotient_polys
-            .into_par_iter()
-            .flat_map(|mut quotient_poly| {
-                quotient_poly.trim_to_len(quotient_degree).expect(
-                    "Quotient has failed, the vanishing polynomial is not divisible by Z_H",
-                );
-                // Split quotient into degree-n chunks.
-                quotient_poly.chunks(degree)
-            })
-            .collect()
-    );
-
-    let quotient_polys_commitment = timed!(
-        timing,
-        "commit to quotient polys",
-        PolynomialBatch::<F, C, D>::from_coeffs(
-            all_quotient_poly_chunks,
-            config.fri_config.rate_bits,
-            config.zero_knowledge && PlonkOracle::QUOTIENT.blinding,
-            config.fri_config.cap_height,
+    let quotient_polys = with_timer("plonk/compute quotient polys", || {
+        timed!(
             timing,
-            prover_data.fft_root_table.as_ref(),
+            "compute quotient polys",
+            compute_quotient_polys::<F, C, D>(
+                common_data,
+                prover_data,
+                &public_inputs_hash,
+                &wires_commitment,
+                &partial_products_zs_and_lookup_commitment,
+                &betas,
+                &gammas,
+                &deltas,
+                &alphas,
+            )
         )
-    );
+    });
+
+    let all_quotient_poly_chunks: Vec<PolynomialCoeffs<F>> =
+        with_timer("plonk/split quotient polys", || {
+            timed!(
+                timing,
+                "split up quotient polys",
+                quotient_polys
+                    .into_par_iter()
+                    .flat_map(|mut quotient_poly| {
+                        quotient_poly.trim_to_len(quotient_degree).expect(
+                            "Quotient has failed, the vanishing polynomial is not divisible by Z_H",
+                        );
+                        // Split quotient into degree-n chunks.
+                        quotient_poly.chunks(degree)
+                    })
+                    .collect()
+            )
+        });
+
+    let quotient_polys_commitment = with_timer_async("plonk/commit quotient polys", || async {
+        timed!(
+            timing,
+            "commit to quotient polys",
+            PolynomialBatch::<F, C, D>::from_coeffs_async(
+                all_quotient_poly_chunks,
+                config.fri_config.rate_bits,
+                config.zero_knowledge && PlonkOracle::QUOTIENT.blinding,
+                config.fri_config.cap_height,
+                timing,
+                prover_data.fft_root_table.as_ref(),
+            )
+            .await
+        )
+    })
+    .await;
 
     challenger.observe_cap::<C::Hasher>(&quotient_polys_commitment.merkle_tree.cap);
 
@@ -369,40 +478,46 @@ where
         "Opening point is in the subgroup."
     );
 
-    let openings = timed!(
-        timing,
-        "construct the opening set, including lookups",
-        OpeningSet::new(
-            zeta,
-            g,
-            &prover_data.constants_sigmas_commitment,
-            &wires_commitment,
-            &partial_products_zs_and_lookup_commitment,
-            &quotient_polys_commitment,
-            common_data
-        )
-    );
-    challenger.observe_openings(&openings.to_fri_openings());
-    let instance = common_data.get_fri_instance(zeta);
-
-    let opening_proof = timed!(
-        timing,
-        "compute opening proofs",
-        PolynomialBatch::<F, C, D>::prove_openings(
-            &instance,
-            &[
+    let openings = with_timer("plonk/construct opening set", || {
+        timed!(
+            timing,
+            "construct the opening set, including lookups",
+            OpeningSet::new(
+                zeta,
+                g,
                 &prover_data.constants_sigmas_commitment,
                 &wires_commitment,
                 &partial_products_zs_and_lookup_commitment,
                 &quotient_polys_commitment,
-            ],
-            &mut challenger,
-            &common_data.fri_params,
-            None,
-            None,
-            timing,
+                common_data,
+            )
         )
-    );
+    });
+    challenger.observe_openings(&openings.to_fri_openings());
+    let instance = common_data.get_fri_instance(zeta);
+
+    let opening_proof = with_timer_async("plonk/FRI opening proof", || async {
+        timed!(
+            timing,
+            "compute opening proofs",
+            PolynomialBatch::<F, C, D>::prove_openings_async(
+                &instance,
+                &[
+                    &prover_data.constants_sigmas_commitment,
+                    &wires_commitment,
+                    &partial_products_zs_and_lookup_commitment,
+                    &quotient_polys_commitment,
+                ],
+                &mut challenger,
+                &common_data.fri_params,
+                None,
+                None,
+                timing,
+            )
+            .await
+        )
+    })
+    .await;
 
     let proof = Proof::<F, C, D> {
         wires_cap: wires_commitment.merkle_tree.cap.clone(),
@@ -698,6 +813,58 @@ where
     ))
 }
 
+#[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
+pub fn prove_with_partition_witness<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+>(
+    prover_data: &ProverOnlyCircuitData<F, C, D>,
+    common_data: &CommonCircuitData<F, D>,
+    partition_witness: PartitionWitness<'_, F>,
+    timing: &mut TimingTree,
+) -> Result<ProofWithPublicInputs<F, C, D>>
+where
+    C::Hasher: Hasher<F>,
+    C::InnerHasher: Hasher<F>,
+{
+    #[cfg(feature = "std")]
+    {
+        block_on(prove_with_partition_witness_async(
+            prover_data,
+            common_data,
+            partition_witness,
+            timing,
+        ))
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        panic!(
+            "plonk::prover::prove_with_partition_witness requires the `std` feature when async proving is enabled"
+        );
+    }
+}
+
+#[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+pub fn prove_with_partition_witness<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+>(
+    _prover_data: &ProverOnlyCircuitData<F, C, D>,
+    _common_data: &CommonCircuitData<F, D>,
+    _partition_witness: PartitionWitness<'_, F>,
+    _timing: &mut TimingTree,
+) -> Result<ProofWithPublicInputs<F, C, D>>
+where
+    C::Hasher: Hasher<F>,
+    C::InnerHasher: Hasher<F>,
+{
+    panic!(
+        "plonk::prover::prove_with_partition_witness must be awaited on wasm with gpu_merkle enabled"
+    );
+}
+
 /// Compute the partial products used in the `Z` polynomials.
 fn all_wires_permutation_partial_products<
     F: RichField + Extendable<D>,
@@ -943,6 +1110,102 @@ fn compute_all_lookup_polys<
 
 const BATCH_SIZE: usize = 32;
 
+#[cfg(feature = "std")]
+#[derive(Default)]
+struct QuotientEvalStats {
+    gather_ns: AtomicU64,
+    eval_ns: AtomicU64,
+    scale_ns: AtomicU64,
+    batches: AtomicU64,
+}
+
+#[cfg(feature = "std")]
+impl QuotientEvalStats {
+    fn record_gather(&self, elapsed: core::time::Duration) {
+        self.gather_ns
+            .fetch_add(elapsed.as_nanos() as u64, Ordering::Relaxed);
+    }
+
+    fn record_eval(&self, elapsed: core::time::Duration) {
+        self.eval_ns
+            .fetch_add(elapsed.as_nanos() as u64, Ordering::Relaxed);
+    }
+
+    fn record_scale(&self, elapsed: core::time::Duration) {
+        self.scale_ns
+            .fetch_add(elapsed.as_nanos() as u64, Ordering::Relaxed);
+    }
+
+    fn inc_batches(&self) {
+        self.batches.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn log(&self, label: &str) {
+        let batches = self.batches.load(Ordering::Relaxed);
+        if batches == 0 {
+            return;
+        }
+        let to_ms = |ns: u64| ns as f64 / 1_000_000.0;
+        log::info!(
+            "{label} -> gather {:.3} ms, eval {:.3} ms, scale {:.3} ms across {} batches",
+            to_ms(self.gather_ns.load(Ordering::Relaxed)),
+            to_ms(self.eval_ns.load(Ordering::Relaxed)),
+            to_ms(self.scale_ns.load(Ordering::Relaxed)),
+            batches
+        );
+    }
+}
+
+#[cfg(not(feature = "std"))]
+#[derive(Default)]
+struct QuotientEvalStats;
+
+#[cfg(not(feature = "std"))]
+impl QuotientEvalStats {
+    fn record_gather(&self, _elapsed: core::time::Duration) {}
+    fn record_eval(&self, _elapsed: core::time::Duration) {}
+    fn record_scale(&self, _elapsed: core::time::Duration) {}
+    fn inc_batches(&self) {}
+    fn log(&self, _label: &str) {}
+}
+
+#[cfg(all(feature = "std", target_arch = "wasm32"))]
+#[derive(Clone, Copy)]
+struct ProfilingInstant {
+    start_ms: f64,
+}
+
+#[cfg(all(feature = "std", target_arch = "wasm32"))]
+impl ProfilingInstant {
+    fn now() -> Self {
+        Self { start_ms: Date::now() }
+    }
+
+    fn elapsed(&self) -> core::time::Duration {
+        let delta_ms = Date::now() - self.start_ms;
+        core::time::Duration::from_secs_f64(delta_ms / 1000.0)
+    }
+}
+
+#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
+#[derive(Clone, Copy)]
+struct ProfilingInstant {
+    inner: Instant,
+}
+
+#[cfg(all(feature = "std", not(target_arch = "wasm32")))]
+impl ProfilingInstant {
+    fn now() -> Self {
+        Self {
+            inner: Instant::now(),
+        }
+    }
+
+    fn elapsed(&self) -> core::time::Duration {
+        self.inner.elapsed()
+    }
+}
+
 fn compute_quotient_polys<
     'a,
     F: RichField + Extendable<D>,
@@ -1021,6 +1284,8 @@ fn compute_quotient_polys<
     let points_batches = points.par_chunks(BATCH_SIZE);
     let num_batches = points.len().div_ceil(BATCH_SIZE);
 
+    let quotient_stats = QuotientEvalStats::default();
+
     let quotient_values: Vec<Vec<F>> = points_batches
         .enumerate()
         .flat_map(|(batch_i, xs_batch)| {
@@ -1045,6 +1310,11 @@ fn compute_quotient_polys<
 
             let mut local_constants_batch_refs = Vec::with_capacity(xs_batch.len());
             let mut local_wires_batch_refs = Vec::with_capacity(xs_batch.len());
+
+            #[cfg(feature = "std")]
+            quotient_stats.inc_batches();
+            #[cfg(feature = "std")]
+            let gather_start = ProfilingInstant::now();
 
             for (&i, &x) in indices_batch.iter().zip(xs_batch) {
                 let shifted_x = F::coset_shift() * x;
@@ -1090,6 +1360,9 @@ fn compute_quotient_polys<
                 s_sigmas_batch.push(s_sigmas);
             }
 
+            #[cfg(feature = "std")]
+            quotient_stats.record_gather(gather_start.elapsed());
+
             // NB (JN): I'm not sure how (in)efficient the below is. It needs measuring.
             let mut local_constants_batch =
                 vec![F::ZERO; xs_batch.len() * local_constants_batch_refs[0].len()];
@@ -1114,6 +1387,8 @@ fn compute_quotient_polys<
                 public_inputs_hash,
             );
 
+            #[cfg(feature = "std")]
+            let eval_start = ProfilingInstant::now();
             let mut quotient_values_batch = eval_vanishing_poly_base_batch::<F, D>(
                 common_data,
                 &indices_batch,
@@ -1132,7 +1407,11 @@ fn compute_quotient_polys<
                 &z_h_on_coset,
                 &lut_re_poly_evals_refs,
             );
+            #[cfg(feature = "std")]
+            quotient_stats.record_eval(eval_start.elapsed());
 
+            #[cfg(feature = "std")]
+            let scale_start = ProfilingInstant::now();
             for (&i, quotient_values) in indices_batch.iter().zip(quotient_values_batch.iter_mut())
             {
                 let denominator_inv = z_h_on_coset.eval_inverse(i);
@@ -1140,13 +1419,19 @@ fn compute_quotient_polys<
                     .iter_mut()
                     .for_each(|v| *v *= denominator_inv);
             }
+            #[cfg(feature = "std")]
+            quotient_stats.record_scale(scale_start.elapsed());
             quotient_values_batch
         })
         .collect();
 
-    transpose(&quotient_values)
-        .into_par_iter()
-        .map(PolynomialValues::new)
-        .map(|values| values.coset_ifft(F::coset_shift()))
-        .collect()
+    quotient_stats.log("plonk quotient constraints detail");
+
+    with_timer("plonk quotient coset IFFT", || {
+        transpose(&quotient_values)
+            .into_par_iter()
+            .map(PolynomialValues::new)
+            .map(|values| values.coset_ifft(F::coset_shift()))
+            .collect()
+    })
 }

--- a/plonky2/src/plonk/prover.rs
+++ b/plonky2/src/plonk/prover.rs
@@ -10,7 +10,7 @@ use anyhow::{ensure, Result};
     feature = "std",
     not(all(feature = "gpu_merkle", target_arch = "wasm32"))
 ))]
-use futures::executor::block_on;
+use pollster::block_on;
 use hashbrown::HashMap;
 use plonky2_maybe_rayon::*;
 

--- a/plonky2/src/plonk/prover.rs
+++ b/plonky2/src/plonk/prover.rs
@@ -867,9 +867,12 @@ where
     }
     #[cfg(not(feature = "std"))]
     {
-        panic!(
-            "plonk::prover::prove_with_partition_witness requires the `std` feature when async proving is enabled"
-        );
+        crate::util::nostd_block_on(prove_with_partition_witness_async(
+            prover_data,
+            common_data,
+            partition_witness,
+            timing,
+        ))
     }
 }
 

--- a/plonky2/src/recursion/cyclic_recursion.rs
+++ b/plonky2/src/recursion/cyclic_recursion.rs
@@ -174,6 +174,30 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         )?;
         Ok(())
     }
+
+    #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+    pub async fn conditionally_verify_cyclic_proof_or_dummy_async<
+        C: GenericConfig<D, F = F> + 'static,
+    >(
+        &mut self,
+        condition: BoolTarget,
+        cyclic_proof_with_pis: &ProofWithPublicInputsTarget<D>,
+        common_data: &CommonCircuitData<F, D>,
+    ) -> Result<()>
+    where
+        C::Hasher: AlgebraicHasher<F>,
+    {
+        let (dummy_proof_with_pis_target, dummy_verifier_data_target) =
+            self.dummy_proof_and_vk_async::<C>(common_data).await?;
+        self.conditionally_verify_cyclic_proof::<C>(
+            condition,
+            cyclic_proof_with_pis,
+            &dummy_proof_with_pis_target,
+            &dummy_verifier_data_target,
+            common_data,
+        )?;
+        Ok(())
+    }
 }
 
 /// Additional checks to be performed on a cyclic recursive proof in addition to verifying the proof.

--- a/plonky2/src/recursion/dummy_circuit.rs
+++ b/plonky2/src/recursion/dummy_circuit.rs
@@ -239,7 +239,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             proof_with_pis_target: dummy_proof_with_pis_target.clone(),
             proof_with_pis: dummy_proof_with_pis,
             verifier_data_target: dummy_verifier_data_target.clone(),
-            verifier_data: dummy_circuit.verifier_only,
+            verifier_data: dummy_circuit.verifier_data(),
         });
 
         Ok((dummy_proof_with_pis_target, dummy_verifier_data_target))

--- a/plonky2/src/recursion/dummy_circuit.rs
+++ b/plonky2/src/recursion/dummy_circuit.rs
@@ -69,6 +69,35 @@ where
     .unwrap()
 }
 
+pub async fn cyclic_base_proof_async<F, C, const D: usize>(
+    common_data: &CommonCircuitData<F, D>,
+    verifier_data: &VerifierOnlyCircuitData<C, D>,
+    mut nonzero_public_inputs: HashMap<usize, F>,
+) -> ProofWithPublicInputs<F, C, D>
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    C::Hasher: AlgebraicHasher<C::F>,
+{
+    let pis_len = common_data.num_public_inputs;
+    let cap_elements = common_data.config.fri_config.num_cap_elements();
+    let start_vk_pis = pis_len - 4 - 4 * cap_elements;
+
+    nonzero_public_inputs.extend((start_vk_pis..).zip(verifier_data.circuit_digest.elements));
+    for i in 0..cap_elements {
+        let start = start_vk_pis + 4 + 4 * i;
+        nonzero_public_inputs
+            .extend((start..).zip(verifier_data.constants_sigmas_cap.0[i].elements));
+    }
+
+    dummy_proof_async::<F, C, D>(
+        &dummy_circuit_async::<F, C, D>(common_data).await,
+        nonzero_public_inputs,
+    )
+    .await
+    .unwrap()
+}
+
 /// Generate a proof for a dummy circuit. The `public_inputs` parameter let the caller specify
 /// certain public inputs (identified by their indices) which should be given specific values.
 /// The rest will default to zero.
@@ -84,6 +113,24 @@ where
         pw.set_target(circuit.prover_only.public_inputs[i], pi)?;
     }
     circuit.prove(pw)
+}
+
+pub async fn dummy_proof_async<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+>(
+    circuit: &CircuitData<F, C, D>,
+    nonzero_public_inputs: HashMap<usize, F>,
+) -> anyhow::Result<ProofWithPublicInputs<F, C, D>>
+where
+{
+    let mut pw = PartialWitness::new();
+    for i in 0..circuit.common.num_public_inputs {
+        let pi = nonzero_public_inputs.get(&i).copied().unwrap_or_default();
+        pw.set_target(circuit.prover_only.public_inputs[i], pi);
+    }
+    circuit.prove_async(pw).await
 }
 
 /// Generate a circuit matching a given `CommonCircuitData`.
@@ -117,6 +164,38 @@ pub fn dummy_circuit<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, c
     circuit
 }
 
+pub async fn dummy_circuit_async<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+>(
+    common_data: &CommonCircuitData<F, D>,
+) -> CircuitData<F, C, D> {
+    let config = common_data.config.clone();
+    assert!(
+        !common_data.config.zero_knowledge,
+        "Degree calculation can be off if zero-knowledge is on."
+    );
+
+    let degree = common_data.degree();
+    let num_noop_gate = degree - common_data.num_public_inputs.div_ceil(8) - 2;
+
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    for _ in 0..num_noop_gate {
+        builder.add_gate(NoopGate, vec![]);
+    }
+    for gate in &common_data.gates {
+        builder.add_gate_to_gate_set(gate.clone());
+    }
+    for _ in 0..common_data.num_public_inputs {
+        builder.add_virtual_public_input();
+    }
+
+    let circuit = builder.build_async::<C>().await;
+    assert_eq!(&circuit.common, common_data);
+    circuit
+}
+
 impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     pub(crate) fn dummy_proof_and_vk<C: GenericConfig<D, F = F> + 'static>(
         &mut self,
@@ -136,6 +215,31 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             proof_with_pis: dummy_proof_with_pis,
             verifier_data_target: dummy_verifier_data_target.clone(),
             verifier_data: dummy_circuit.verifier_data(),
+        });
+
+        Ok((dummy_proof_with_pis_target, dummy_verifier_data_target))
+    }
+
+    #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+    pub(crate) async fn dummy_proof_and_vk_async<C: GenericConfig<D, F = F> + 'static>(
+        &mut self,
+        common_data: &CommonCircuitData<F, D>,
+    ) -> anyhow::Result<(ProofWithPublicInputsTarget<D>, VerifierCircuitTarget)>
+    where
+        C::Hasher: AlgebraicHasher<F>,
+    {
+        let dummy_circuit = dummy_circuit_async::<F, C, D>(common_data).await;
+        let dummy_proof_with_pis =
+            dummy_proof_async::<F, C, D>(&dummy_circuit, HashMap::new()).await?;
+        let dummy_proof_with_pis_target = self.add_virtual_proof_with_pis(common_data);
+        let dummy_verifier_data_target =
+            self.add_virtual_verifier_data(self.config.fri_config.cap_height);
+
+        self.add_simple_generator(DummyProofGenerator {
+            proof_with_pis_target: dummy_proof_with_pis_target.clone(),
+            proof_with_pis: dummy_proof_with_pis,
+            verifier_data_target: dummy_verifier_data_target.clone(),
+            verifier_data: dummy_circuit.verifier_only,
         });
 
         Ok((dummy_proof_with_pis_target, dummy_verifier_data_target))

--- a/plonky2/src/recursion/dummy_circuit.rs
+++ b/plonky2/src/recursion/dummy_circuit.rs
@@ -128,7 +128,12 @@ where
     let mut pw = PartialWitness::new();
     for i in 0..circuit.common.num_public_inputs {
         let pi = nonzero_public_inputs.get(&i).copied().unwrap_or_default();
-        pw.set_target(circuit.prover_only.public_inputs[i], pi);
+        // SECURITY (H-1): the sync sibling propagates this Result with `?`;
+        // dropping it silently would let `set_target` failures (e.g. the
+        // target already being assigned to a conflicting value) advance the
+        // prover with an inconsistent witness, producing either a later
+        // panic or a malformed proof.
+        pw.set_target(circuit.prover_only.public_inputs[i], pi)?;
     }
     circuit.prove_async(pw).await
 }

--- a/plonky2/src/recursion/recursive_verifier.rs
+++ b/plonky2/src/recursion/recursive_verifier.rs
@@ -699,7 +699,7 @@ mod tests {
         let proof_from_bytes = ProofWithPublicInputs::from_bytes(proof_bytes, common_data)?;
         assert_eq!(proof, &proof_from_bytes);
 
-        #[cfg(feature = "std")]
+        #[cfg(all(feature = "std", not(target_family = "wasm")))]
         let now = std::time::Instant::now();
 
         let compressed_proof = proof.clone().compress(&vd.circuit_digest, common_data)?;
@@ -707,7 +707,7 @@ mod tests {
             .clone()
             .decompress(&vd.circuit_digest, common_data)?;
 
-        #[cfg(feature = "std")]
+        #[cfg(all(feature = "std", not(target_family = "wasm")))]
         info!("{:.4}s to compress proof", now.elapsed().as_secs_f64());
 
         assert_eq!(proof, &decompressed_compressed_proof);

--- a/plonky2/src/util/mod.rs
+++ b/plonky2/src/util/mod.rs
@@ -13,6 +13,7 @@ use crate::field::types::Field;
 pub mod builder_hook;
 pub(crate) mod context_tree;
 pub(crate) mod partial_products;
+pub mod profiling;
 pub mod reducing;
 pub mod serialization;
 pub mod strided_view;

--- a/plonky2/src/util/mod.rs
+++ b/plonky2/src/util/mod.rs
@@ -19,6 +19,44 @@ pub mod serialization;
 pub mod strided_view;
 pub mod timing;
 
+/// `no_std`-friendly future driver used by the synchronous prover wrappers
+/// when the `std` feature is disabled. On non-wasm-gpu builds the futures
+/// produced by `*_async` entry points are constructed from purely
+/// synchronous CPU code (no real I/O, no `wasm_bindgen_futures`), so they
+/// resolve on the very first poll.
+///
+/// We provide a tiny single-poll executor here so that the sync wrappers
+/// (e.g. `prove_with_partition_witness`, `fri_proof`,
+/// `PolynomialBatch::prove_openings`) can be called from `no_std`
+/// environments without pulling in `pollster` or `futures::executor`,
+/// both of which require `std`.
+///
+/// On `cfg(feature = "std")` we always prefer `pollster::block_on`, so
+/// this helper is gated to `no_std`.
+#[cfg(not(feature = "std"))]
+pub(crate) fn nostd_block_on<Fut: core::future::Future>(fut: Fut) -> Fut::Output {
+    use core::pin::pin;
+    use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
+    // A no-op waker: all four vtable hooks are empty since we never park.
+    const VTABLE: RawWakerVTable =
+        RawWakerVTable::new(|p| RawWaker::new(p, &VTABLE), |_| {}, |_| {}, |_| {});
+    let raw = RawWaker::new(core::ptr::null(), &VTABLE);
+    // SAFETY: the vtable above honours all four `Waker` invariants
+    // (clone returns a fresh `RawWaker` with the same vtable; wake / wake_by_ref / drop are no-ops).
+    let waker = unsafe { Waker::from_raw(raw) };
+    let mut cx = Context::from_waker(&waker);
+    let mut fut = pin!(fut);
+    match fut.as_mut().poll(&mut cx) {
+        Poll::Ready(v) => v,
+        Poll::Pending => panic!(
+            "nostd_block_on: future returned Pending, but the synchronous \
+             wrapper expected an immediately-Ready future. This indicates \
+             a real async operation reached a no_std code path."
+        ),
+    }
+}
+
 pub(crate) fn transpose_poly_values<F: Field>(polys: Vec<PolynomialValues<F>>) -> Vec<Vec<F>> {
     let poly_values = polys.into_iter().map(|p| p.values).collect::<Vec<_>>();
     transpose(&poly_values)

--- a/plonky2/src/util/profiling.rs
+++ b/plonky2/src/util/profiling.rs
@@ -1,6 +1,7 @@
 //! Lightweight timing helpers that work on both native targets and wasm.
 
 use core::future::Future;
+
 use log::info;
 
 /// Execute `action`, logging the elapsed time with `label`.

--- a/plonky2/src/util/profiling.rs
+++ b/plonky2/src/util/profiling.rs
@@ -1,0 +1,77 @@
+//! Lightweight timing helpers that work on both native targets and wasm.
+
+use core::future::Future;
+use log::info;
+
+/// Execute `action`, logging the elapsed time with `label`.
+#[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
+pub fn with_timer<T, F>(label: &str, action: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    let start = std::time::Instant::now();
+    let output = action();
+    let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+    info!("{label} took {:.3} ms", elapsed_ms);
+    output
+}
+
+/// Execute `action`, logging the elapsed time with `label`.
+#[cfg(target_arch = "wasm32")]
+pub fn with_timer<T, F>(label: &str, action: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    let start = js_sys::Date::now();
+    let output = action();
+    let elapsed_ms = js_sys::Date::now() - start;
+    info!("{label} took {:.3} ms", elapsed_ms);
+    output
+}
+
+/// Fallback implementation when `std` is unavailable; simply runs the closure without logging.
+#[cfg(all(not(target_arch = "wasm32"), not(feature = "std")))]
+pub fn with_timer<T, F>(_label: &str, action: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    action()
+}
+
+/// Async variant of [`with_timer`] for operations that need `.await`.
+#[cfg(all(not(target_arch = "wasm32"), feature = "std"))]
+pub async fn with_timer_async<T, F, Fut>(label: &str, action: F) -> T
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = T>,
+{
+    let start = std::time::Instant::now();
+    let output = action().await;
+    let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+    info!("{label} took {:.3} ms", elapsed_ms);
+    output
+}
+
+/// Async variant of [`with_timer`] that works on wasm targets.
+#[cfg(target_arch = "wasm32")]
+pub async fn with_timer_async<T, F, Fut>(label: &str, action: F) -> T
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = T>,
+{
+    let start = js_sys::Date::now();
+    let output = action().await;
+    let elapsed_ms = js_sys::Date::now() - start;
+    info!("{label} took {:.3} ms", elapsed_ms);
+    output
+}
+
+/// Fallback async implementation when `std` is unavailable.
+#[cfg(all(not(target_arch = "wasm32"), not(feature = "std")))]
+pub async fn with_timer_async<T, F, Fut>(_label: &str, action: F) -> T
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = T>,
+{
+    action().await
+}

--- a/starky/Cargo.toml
+++ b/starky/Cargo.toml
@@ -16,6 +16,7 @@ default = ["parallel", "std", "timing"]
 parallel = ["plonky2/parallel", "plonky2_maybe_rayon/parallel"]
 std = ["anyhow/std", "plonky2/std"]
 timing = ["plonky2/timing"]
+gpu_merkle = []
 
 [dependencies]
 ahash = { workspace = true }

--- a/starky/src/prover.rs
+++ b/starky/src/prover.rs
@@ -122,6 +122,7 @@ pub fn prove<F, C, S, const D: usize>(
     _config: &StarkConfig,
     _trace_poly_values: Vec<PolynomialValues<F>>,
     _public_inputs: &[F],
+    _verifier_circuit_fri_params: Option<FriParams>,
     _timing: &mut TimingTree,
 ) -> Result<StarkProofWithPublicInputs<F, C, D>>
 where
@@ -138,6 +139,7 @@ pub async fn prove_async<F, C, S, const D: usize>(
     config: &StarkConfig,
     trace_poly_values: Vec<PolynomialValues<F>>,
     public_inputs: &[F],
+    verifier_circuit_fri_params: Option<FriParams>,
     timing: &mut TimingTree,
 ) -> Result<StarkProofWithPublicInputs<F, C, D>>
 where
@@ -147,7 +149,14 @@ where
 {
     #[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
     {
-        return prove::<F, C, S, D>(stark, config, trace_poly_values, public_inputs, timing);
+        return prove::<F, C, S, D>(
+            stark,
+            config,
+            trace_poly_values,
+            public_inputs,
+            verifier_circuit_fri_params,
+            timing,
+        );
     }
 
     #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
@@ -161,6 +170,27 @@ where
             fri_params.total_arities() <= degree_bits + rate_bits - cap_height,
             "FRI total reduction arity is too large.",
         );
+
+        let (final_poly_coeff_len, max_num_query_steps) =
+            if let Some(verifier_circuit_fri_params) = verifier_circuit_fri_params {
+                assert_eq!(verifier_circuit_fri_params.config, fri_params.config);
+                match &config.fri_config.reduction_strategy {
+                    FriReductionStrategy::ConstantArityBits(_, final_poly_bits) => {
+                        let len = final_poly_coeff_len(
+                            verifier_circuit_fri_params.degree_bits,
+                            &verifier_circuit_fri_params.reduction_arity_bits,
+                        );
+                        assert_eq!(len, 1 << (1 + *final_poly_bits));
+                        (
+                            Some(len),
+                            Some(verifier_circuit_fri_params.reduction_arity_bits.len()),
+                        )
+                    }
+                    _ => panic!("Fri Reduction Strategy is not ConstantArityBits"),
+                }
+            } else {
+                (None, None)
+            };
 
         let trace_commitment = timed!(
             timing,
@@ -189,6 +219,8 @@ where
             None,
             &mut challenger,
             public_inputs,
+            final_poly_coeff_len,
+            max_num_query_steps,
             timing,
         )
         .await
@@ -578,6 +610,8 @@ pub fn prove_with_commitment<F, C, S, const D: usize>(
     _ctl_challenges: Option<&GrandProductChallengeSet<F>>,
     _challenger: &mut Challenger<F, C::Hasher>,
     _public_inputs: &[F],
+    _final_poly_coeff_len: Option<usize>,
+    _max_num_query_steps: Option<usize>,
     _timing: &mut TimingTree,
 ) -> Result<StarkProofWithPublicInputs<F, C, D>>
 where
@@ -609,6 +643,8 @@ pub async fn prove_with_commitment_async<'a, F, C, S, const D: usize>(
     ctl_challenges: Option<&'a GrandProductChallengeSet<F>>,
     challenger: &'a mut Challenger<F, C::Hasher>,
     public_inputs: &'a [F],
+    final_poly_coeff_len: Option<usize>,
+    max_num_query_steps: Option<usize>,
     timing: &'a mut TimingTree,
 ) -> Result<StarkProofWithPublicInputs<F, C, D>>
 where
@@ -627,6 +663,8 @@ where
             ctl_challenges,
             challenger,
             public_inputs,
+            final_poly_coeff_len,
+            max_num_query_steps,
             timing,
         );
     }

--- a/starky/src/prover.rs
+++ b/starky/src/prover.rs
@@ -149,14 +149,14 @@ where
 {
     #[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
     {
-        return prove::<F, C, S, D>(
+        prove::<F, C, S, D>(
             stark,
             config,
             trace_poly_values,
             public_inputs,
             verifier_circuit_fri_params,
             timing,
-        );
+        )
     }
 
     #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
@@ -661,7 +661,7 @@ where
 {
     #[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
     {
-        return prove_with_commitment(
+        prove_with_commitment(
             stark,
             config,
             trace_poly_values,
@@ -673,7 +673,7 @@ where
             final_poly_coeff_len,
             max_num_query_steps,
             timing,
-        );
+        )
     }
 
     #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]

--- a/starky/src/prover.rs
+++ b/starky/src/prover.rs
@@ -208,6 +208,13 @@ where
 
         let trace_cap = trace_commitment.merkle_tree.cap.clone();
         let mut challenger = Challenger::new();
+        // SECURITY (C-1): match the sync `prove` Fiat-Shamir transcript exactly.
+        // `StarkProofWithPublicInputs::get_challenges` (verifier side) observes
+        // public_inputs first, then config, then trace_cap (in that order).
+        // Lita's wasm-gpu prove_async originally only observed trace_cap, so
+        // every async-built proof failed verification.
+        challenger.observe_elements(public_inputs);
+        config.observe(&mut challenger);
         challenger.observe_cap(&trace_cap);
 
         prove_with_commitment_async(
@@ -761,7 +768,16 @@ where
             challenger.observe_cap(cap);
         }
 
-        let alphas = challenger.get_n_challenges(config.num_challenges);
+        // SECURITY (C-2): mirror the constraint-binding stage from the sync
+        // `prove_with_commitment` (lines ~361-492). Lita's async port jumped
+        // straight from `auxiliary_polys_cap` observation to `alphas =
+        // get_n_challenges`, skipping `alphas_prime`, the simulating-zeta
+        // sampling, dummy opening-set evaluation, `zeta_prime`,
+        // `compute_eval_vanishing_poly`, and the `observe_extension_elements`
+        // step that the verifier (`get_challenges`) performs. Without these,
+        // the prover's `alphas` and the verifier's `alphas` differ on every
+        // run, so all proofs are silently rejected.
+        let alphas_prime = challenger.get_n_challenges(config.num_challenges);
 
         let num_ctl_polys = ctl_data
             .map(|data| data.num_ctl_helper_polys())
@@ -777,12 +793,107 @@ where
                 lookup_challenges.as_ref(),
                 &lookups,
                 ctl_data,
-                alphas.clone(),
+                alphas_prime.clone(),
                 degree_bits,
                 num_lookup_columns,
                 &num_ctl_polys,
             );
         }
+
+        // Constraint-binding ritual: sample dummy opening evaluations,
+        // evaluate the vanishing polynomial against them, and observe the
+        // result so that the upcoming `alphas` are bound to the constraints.
+        let is_aux_polys = auxiliary_polys_commitment.is_some();
+        let num_auxiliary_polys = auxiliary_polys_commitment
+            .as_ref()
+            .map_or(0, |p| p.polynomials.len());
+        let total_num_ctl_polys = num_ctl_polys.iter().sum::<usize>();
+        let total_num_dummy_extension_evals =
+            trace_commitment.polynomials.len() * 2 + num_auxiliary_polys * 2;
+        let pow_degree = core::cmp::max(2, stark.constraint_degree() + 1);
+        let num_extension_powers = core::cmp::max(1, 50 / log2_ceil(pow_degree) - 1);
+        let simulating_zetas = challenger.get_n_extension_challenges(
+            total_num_dummy_extension_evals.div_ceil(num_extension_powers),
+        );
+        let nb_dummy_per_zeta =
+            core::cmp::min(num_extension_powers + 1, total_num_dummy_extension_evals);
+        let dummy_extension_evals = simulating_zetas
+            .iter()
+            .flat_map(|&zeta| {
+                successors(Some(zeta), move |prev| Some(prev.exp_u64(pow_degree as u64)))
+                    .take(nb_dummy_per_zeta)
+            })
+            .collect::<Vec<_>>();
+
+        let next_values_start = S::COLUMNS;
+        let auxiliary_polys_start = S::COLUMNS * 2;
+        let auxiliary_polys_next_start = auxiliary_polys_start + num_auxiliary_polys;
+
+        let poly_evals = StarkOpeningSet {
+            local_values: dummy_extension_evals[..next_values_start].to_vec(),
+            next_values: dummy_extension_evals[next_values_start..auxiliary_polys_start].to_vec(),
+            auxiliary_polys: if is_aux_polys {
+                Some(
+                    dummy_extension_evals[auxiliary_polys_start..auxiliary_polys_next_start]
+                        .to_vec(),
+                )
+            } else {
+                None
+            },
+            auxiliary_polys_next: if is_aux_polys {
+                Some(dummy_extension_evals[auxiliary_polys_next_start..].to_vec())
+            } else {
+                None
+            },
+            ctl_zs_first: None,
+            quotient_polys: None,
+        };
+
+        let ctl_vars = ctl_data.map(|data| {
+            let mut start_index = 0;
+            data.zs_columns
+                .iter()
+                .enumerate()
+                .map(|(i, zs_columns)| {
+                    let num_ctl_helper_cols = num_ctl_polys[i];
+                    let helper_columns = poly_evals.auxiliary_polys.as_ref().unwrap()
+                        [num_lookup_columns + start_index
+                            ..num_lookup_columns + start_index + num_ctl_helper_cols]
+                        .to_vec();
+                    let ctl_vars = CtlCheckVars::<F, F::Extension, F::Extension, D> {
+                        helper_columns,
+                        local_z: poly_evals.auxiliary_polys.as_ref().unwrap()
+                            [num_lookup_columns + total_num_ctl_polys + i],
+                        next_z: poly_evals.auxiliary_polys_next.as_ref().unwrap()
+                            [num_lookup_columns + total_num_ctl_polys + i],
+                        challenges: zs_columns.challenge,
+                        columns: zs_columns.columns.clone(),
+                        filter: zs_columns.filter.clone(),
+                    };
+                    start_index += num_ctl_helper_cols;
+                    ctl_vars
+                })
+                .collect::<Vec<_>>()
+        });
+
+        let zeta_prime = challenger.get_extension_challenge::<D>();
+
+        let constraints = compute_eval_vanishing_poly::<F, S, D>(
+            stark,
+            &poly_evals,
+            ctl_vars.as_deref(),
+            lookup_challenges.as_ref(),
+            &lookups,
+            public_inputs,
+            alphas_prime.clone(),
+            zeta_prime,
+            degree_bits,
+            num_lookup_columns,
+        );
+
+        challenger.observe_extension_elements(&constraints);
+
+        let alphas = challenger.get_n_challenges(config.num_challenges);
 
         let quotient_polys = timed!(
             timing,

--- a/starky/src/prover.rs
+++ b/starky/src/prover.rs
@@ -20,6 +20,7 @@ use plonky2::hash::hash_types::RichField;
 use plonky2::iop::challenger::Challenger;
 use plonky2::plonk::config::GenericConfig;
 use plonky2::timed;
+use plonky2::util::profiling::with_timer;
 use plonky2::util::timing::TimingTree;
 use plonky2::util::{log2_ceil, log2_strict, transpose};
 use plonky2_maybe_rayon::*;
@@ -37,6 +38,7 @@ use crate::stark::Stark;
 use crate::vanishing_poly::{compute_eval_vanishing_poly, eval_vanishing_poly};
 
 /// From a STARK trace, computes a STARK proof to attest its correctness.
+#[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
 pub fn prove<F, C, S, const D: usize>(
     stark: S,
     config: &StarkConfig,
@@ -113,6 +115,86 @@ where
     )
 }
 
+/// Synchronous proving is unsupported on `wasm32` with `gpu_merkle`; call [`prove_async`] instead.
+#[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+pub fn prove<F, C, S, const D: usize>(
+    _stark: S,
+    _config: &StarkConfig,
+    _trace_poly_values: Vec<PolynomialValues<F>>,
+    _public_inputs: &[F],
+    _timing: &mut TimingTree,
+) -> Result<StarkProofWithPublicInputs<F, C, D>>
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    S: Stark<F, D>,
+{
+    panic!("Stark prover must be awaited on wasm with gpu_merkle enabled; use prove_async instead");
+}
+
+/// WASM-friendly async variant of [`prove`] that uses GPU Merkle builders when available.
+pub async fn prove_async<F, C, S, const D: usize>(
+    stark: S,
+    config: &StarkConfig,
+    trace_poly_values: Vec<PolynomialValues<F>>,
+    public_inputs: &[F],
+    timing: &mut TimingTree,
+) -> Result<StarkProofWithPublicInputs<F, C, D>>
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    S: Stark<F, D>,
+{
+    #[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
+    {
+        return prove::<F, C, S, D>(stark, config, trace_poly_values, public_inputs, timing);
+    }
+
+    #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+    {
+        let degree = trace_poly_values[0].len();
+        let degree_bits = log2_strict(degree);
+        let fri_params = config.fri_params(degree_bits);
+        let rate_bits = config.fri_config.rate_bits;
+        let cap_height = config.fri_config.cap_height;
+        assert!(
+            fri_params.total_arities() <= degree_bits + rate_bits - cap_height,
+            "FRI total reduction arity is too large.",
+        );
+
+        let trace_commitment = timed!(
+            timing,
+            "compute trace commitment",
+            PolynomialBatch::<F, C, D>::from_values_async(
+                trace_poly_values.clone(),
+                rate_bits,
+                false,
+                cap_height,
+                timing,
+                None,
+            )
+            .await
+        );
+
+        let trace_cap = trace_commitment.merkle_tree.cap.clone();
+        let mut challenger = Challenger::new();
+        challenger.observe_cap(&trace_cap);
+
+        prove_with_commitment_async(
+            &stark,
+            config,
+            &trace_poly_values,
+            &trace_commitment,
+            None,
+            None,
+            &mut challenger,
+            public_inputs,
+            timing,
+        )
+        .await
+    }
+}
+
 /// Generates a proof for a single STARK table, including:
 ///
 /// - the initial state of the challenger,
@@ -122,6 +204,7 @@ where
 ///   of a multi-STARK system.
 ///
 /// /!\ Note that this method does not observe the `config`, and it assumes the `config` has already been observed.
+#[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
 pub fn prove_with_commitment<F, C, S, const D: usize>(
     stark: &S,
     config: &StarkConfig,
@@ -483,6 +566,293 @@ where
     })
 }
 
+/// Synchronous proving with precomputed commitments is unsupported on `wasm32` with `gpu_merkle`; call [`prove_with_commitment_async`] instead.
+#[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+#[track_caller]
+pub fn prove_with_commitment<F, C, S, const D: usize>(
+    _stark: &S,
+    _config: &StarkConfig,
+    _trace_poly_values: &[PolynomialValues<F>],
+    _trace_commitment: &PolynomialBatch<F, C, D>,
+    _ctl_data: Option<&CtlData<F>>,
+    _ctl_challenges: Option<&GrandProductChallengeSet<F>>,
+    _challenger: &mut Challenger<F, C::Hasher>,
+    _public_inputs: &[F],
+    _timing: &mut TimingTree,
+) -> Result<StarkProofWithPublicInputs<F, C, D>>
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    S: Stark<F, D>,
+{
+    #[cfg(feature = "std")]
+    {
+        use std::backtrace::Backtrace;
+        let bt = Backtrace::force_capture();
+        let caller = core::panic::Location::caller();
+        log::error!(
+            "Unexpected call to starky::prover::prove_with_commitment on wasm32+gpu_merkle from {}:{}.\nBacktrace:\n{bt}",
+            caller.file(),
+            caller.line()
+        );
+    }
+    panic!("Stark prover must be awaited on wasm with gpu_merkle enabled; use prove_with_commitment_async instead");
+}
+
+/// WASM-friendly async variant of [`prove_with_commitment`] that awaits GPU commits.
+pub async fn prove_with_commitment_async<'a, F, C, S, const D: usize>(
+    stark: &'a S,
+    config: &'a StarkConfig,
+    trace_poly_values: &'a [PolynomialValues<F>],
+    trace_commitment: &'a PolynomialBatch<F, C, D>,
+    ctl_data: Option<&'a CtlData<'a, F>>,
+    ctl_challenges: Option<&'a GrandProductChallengeSet<F>>,
+    challenger: &'a mut Challenger<F, C::Hasher>,
+    public_inputs: &'a [F],
+    timing: &'a mut TimingTree,
+) -> Result<StarkProofWithPublicInputs<F, C, D>>
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    S: Stark<F, D>,
+{
+    #[cfg(not(all(feature = "gpu_merkle", target_arch = "wasm32")))]
+    {
+        return prove_with_commitment(
+            stark,
+            config,
+            trace_poly_values,
+            trace_commitment,
+            ctl_data,
+            ctl_challenges,
+            challenger,
+            public_inputs,
+            timing,
+        );
+    }
+
+    #[cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))]
+    {
+        let degree = trace_poly_values[0].len();
+        let degree_bits = log2_strict(degree);
+        let fri_params = config.fri_params(degree_bits);
+        let rate_bits = config.fri_config.rate_bits;
+        let cap_height = config.fri_config.cap_height;
+        assert!(
+            fri_params.total_arities() <= degree_bits + rate_bits - cap_height,
+            "FRI total reduction arity is too large.",
+        );
+
+        let constraint_degree = stark.constraint_degree();
+        assert!(
+            constraint_degree <= (1 << rate_bits) + 1,
+            "The degree of the Stark constraints must be <= blowup_factor + 1"
+        );
+
+        let lookup_challenges = stark.uses_lookups().then(|| {
+            if let Some(c) = ctl_challenges {
+                c.challenges.iter().map(|ch| ch.beta).collect::<Vec<_>>()
+            } else {
+                get_grand_product_challenge_set(challenger, config.num_challenges)
+                    .challenges
+                    .iter()
+                    .map(|ch| ch.beta)
+                    .collect::<Vec<_>>()
+            }
+        });
+
+        let lookups = stark.lookups();
+        let lookup_helper_columns = timed!(
+            timing,
+            "compute lookup helper columns",
+            lookup_challenges.as_ref().map(|challenges| {
+                let mut columns = Vec::new();
+                for lookup in &lookups {
+                    for &challenge in challenges {
+                        columns.extend(lookup_helper_columns(
+                            lookup,
+                            trace_poly_values,
+                            challenge,
+                            constraint_degree,
+                        ));
+                    }
+                }
+                columns
+            })
+        );
+        let num_lookup_columns = lookup_helper_columns.as_ref().map_or(0, |v| v.len());
+
+        let auxiliary_polys = match lookup_helper_columns {
+            None => get_ctl_auxiliary_polys(ctl_data),
+            Some(mut lookup_columns) => {
+                if let Some(p) = get_ctl_auxiliary_polys(ctl_data) {
+                    lookup_columns.extend(p)
+                };
+
+                Some(lookup_columns)
+            }
+        };
+
+        debug_assert!(
+            (stark.uses_lookups() || stark.requires_ctls()) || auxiliary_polys.is_none(),
+            "There should be auxiliary polynomials if and only if we have either lookups or require cross-table lookups."
+        );
+
+        let auxiliary_polys_commitment = if let Some(aux_polys) = auxiliary_polys {
+            Some(timed!(
+                timing,
+                "compute auxiliary polynomials commitment",
+                PolynomialBatch::from_values_async(
+                    aux_polys,
+                    rate_bits,
+                    false,
+                    config.fri_config.cap_height,
+                    timing,
+                    None,
+                )
+                .await
+            ))
+        } else {
+            None
+        };
+
+        let auxiliary_polys_cap = auxiliary_polys_commitment
+            .as_ref()
+            .map(|commit| commit.merkle_tree.cap.clone());
+        if let Some(cap) = &auxiliary_polys_cap {
+            challenger.observe_cap(cap);
+        }
+
+        let alphas = challenger.get_n_challenges(config.num_challenges);
+
+        let num_ctl_polys = ctl_data
+            .map(|data| data.num_ctl_helper_polys())
+            .unwrap_or_default();
+
+        #[cfg(debug_assertions)]
+        {
+            check_constraints(
+                stark,
+                trace_commitment,
+                public_inputs,
+                &auxiliary_polys_commitment,
+                lookup_challenges.as_ref(),
+                &lookups,
+                ctl_data,
+                alphas.clone(),
+                degree_bits,
+                num_lookup_columns,
+                &num_ctl_polys,
+            );
+        }
+
+        let quotient_polys = timed!(
+            timing,
+            "compute quotient polys",
+            compute_quotient_polys::<F, <F as Packable>::Packing, C, S, D>(
+                stark,
+                trace_commitment,
+                &auxiliary_polys_commitment,
+                lookup_challenges.as_ref(),
+                &lookups,
+                ctl_data,
+                public_inputs,
+                alphas.clone(),
+                degree_bits,
+                num_lookup_columns,
+                &num_ctl_polys,
+                config,
+            )
+        );
+        let (quotient_commitment, quotient_polys_cap) = if let Some(quotient_polys) = quotient_polys
+        {
+            let all_quotient_chunks = timed!(
+                    timing,
+                    "split quotient polys",
+                    quotient_polys
+                        .into_par_iter()
+                        .flat_map(|mut quotient_poly| {
+                            quotient_poly
+                                .trim_to_len(degree * stark.quotient_degree_factor())
+                                .expect(
+                                    "Quotient has failed, the vanishing polynomial is not divisible by Z_H",
+                                );
+                            quotient_poly.chunks(degree)
+                        })
+                        .collect()
+                );
+            let quotient_commitment = timed!(
+                timing,
+                "compute quotient commitment",
+                PolynomialBatch::from_coeffs_async(
+                    all_quotient_chunks,
+                    rate_bits,
+                    false,
+                    config.fri_config.cap_height,
+                    timing,
+                    None,
+                )
+                .await
+            );
+            let quotient_polys_cap = quotient_commitment.merkle_tree.cap.clone();
+            challenger.observe_cap(&quotient_polys_cap);
+            (Some(quotient_commitment), Some(quotient_polys_cap))
+        } else {
+            (None, None)
+        };
+
+        let zeta = challenger.get_extension_challenge::<D>();
+        let g = F::primitive_root_of_unity(degree_bits);
+        ensure!(
+            zeta.exp_power_of_2(degree_bits) != F::Extension::ONE,
+            "Opening point is in the subgroup."
+        );
+
+        let openings = StarkOpeningSet::new(
+            zeta,
+            g,
+            trace_commitment,
+            auxiliary_polys_commitment.as_ref(),
+            quotient_commitment.as_ref(),
+            stark.num_lookup_helper_columns(config),
+            stark.requires_ctls(),
+            &num_ctl_polys,
+        );
+        challenger.observe_openings(&openings.to_fri_openings());
+
+        let initial_merkle_trees = once(trace_commitment)
+            .chain(&auxiliary_polys_commitment)
+            .chain(&quotient_commitment)
+            .collect_vec();
+
+        let opening_proof = timed!(
+            timing,
+            "compute openings proof",
+            PolynomialBatch::prove_openings_async(
+                &stark.fri_instance(zeta, g, num_ctl_polys.iter().sum(), num_ctl_polys, config),
+                &initial_merkle_trees,
+                challenger,
+                &fri_params,
+                timing,
+            )
+            .await
+        );
+
+        let proof = StarkProof {
+            trace_cap: trace_commitment.merkle_tree.cap.clone(),
+            auxiliary_polys_cap,
+            quotient_polys_cap,
+            openings,
+            opening_proof,
+        };
+
+        Ok(StarkProofWithPublicInputs {
+            proof,
+            public_inputs: public_inputs.to_vec(),
+        })
+    }
+}
+
 /// Computes the quotient polynomials `(sum alpha^i C_i(x)) / Z_H(x)` for `alpha` in `alphas`,
 /// where the `C_i`s are the STARK constraints.
 fn compute_quotient_polys<'a, F, P, C, S, const D: usize>(
@@ -661,13 +1031,15 @@ where
         })
         .collect::<Vec<_>>();
 
-    Some(
+    let quotient_polys = with_timer("starky quotient coset IFFT", || {
         transpose(&quotient_values)
             .into_par_iter()
             .map(PolynomialValues::new)
             .map(|values| values.coset_ifft(F::coset_shift()))
-            .collect(),
-    )
+            .collect()
+    });
+
+    Some(quotient_polys)
 }
 
 /// Check that all constraints evaluate to zero on `H`.

--- a/starky/src/prover.rs
+++ b/starky/src/prover.rs
@@ -820,8 +820,10 @@ where
         let dummy_extension_evals = simulating_zetas
             .iter()
             .flat_map(|&zeta| {
-                successors(Some(zeta), move |prev| Some(prev.exp_u64(pow_degree as u64)))
-                    .take(nb_dummy_per_zeta)
+                successors(Some(zeta), move |prev| {
+                    Some(prev.exp_u64(pow_degree as u64))
+                })
+                .take(nb_dummy_per_zeta)
             })
             .collect::<Vec<_>>();
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,284 @@
+# Lita-Plonky2 `wasm` Branch Port — Plan & Threat Model
+
+**Status:** AWAITING USER APPROVAL — do not begin implementation until approved.
+
+**Goal (option A, confirmed by user):** Port the WebGPU-Merkle-tree work and the surrounding async API cascade from `InternetMaximalism/Lita-Plonky2@wasm` into this repository (`InternetMaximalism/polygon-plonky2`), preserving Lita's existing scope. Multi-threading is **out of scope** because it does not exist in the source branch.
+
+**Branch on which this work will live:** `vulcheck-mle-solidity` is currently checked out; we should branch off `main` to a new feature branch (e.g. `feat/wasm-webgpu-merkle`) before any code lands.
+
+---
+
+## 0. What Lita's `wasm` branch actually contains (verified)
+
+- 5 WGSL shaders under `plonky2/shaders/` (Goldilocks Montgomery + Poseidon + Merkle layer kernel)
+- `plonky2/src/hash/merkle_tree_gpu.rs` (~1990 LOC) — host-side wgpu dispatch
+- `*_async` cascade through prover entry points (FRI prover, FRI oracle, plonk prover, circuit_data)
+- New `plonky2/src/util/profiling.rs` (`with_timer` / `with_timer_async`) and `plonky2/src/util/builder_hook.rs`
+- `Serialize` / `Deserialize` derives on a number of Target / proof types
+- Multiple `gates/*.rs` "less-alloc" refactors (gpu-unrelated)
+- `plonky2/Cargo.toml`: new `gpu_merkle` feature, target-gated wasm32 deps, `cdylib + rlib`
+- `starky/Cargo.toml`: empty placeholder `gpu_merkle` feature
+- **NO** `wasm-bindgen-rayon`, **NO** Web Worker code, **NO** atomics setup, **NO** `.cargo/config.toml`, **NO** JS bindings, **NO** `wasm-pack` config.
+
+**Source-branch assumption to verify before porting:** the diff is computed against Lita's `main`, which is itself diverged from this repo's `main`. We need a 3-way merge view, NOT a literal patch apply.
+
+---
+
+## 1. Threat Model (CLAUDE.md §Security-Critical Mindset compliance)
+
+We will spawn an independent attacker subagent before any code lands. The threat model below is the *prior* — the subagent must extend / contradict it.
+
+### 1.1 Trust boundary
+
+- The prover runs in a hostile JS context (browser). The verifier is elsewhere (e.g. on-chain or a different process). Anything observable in the browser is observable to the user / attacker.
+- WebGPU shaders run on **prover-controlled hardware**. The shader code itself is fixed (compiled in), but the inputs and the GPU driver are attacker-controlled.
+- Read-back of GPU buffers is staged through prover-controlled memory; we re-encode Montgomery → canonical on the GPU before read-back.
+
+### 1.2 Soundness-relevant invariants the port must preserve
+
+I1. **Merkle digest equivalence.** For any leaves `L` and `cap_height h`, `MerkleTree::new(L, h)` (CPU) and `MerkleTree::new_async(L, h)` followed by GPU dispatch must produce *bit-identical* `digests` and `cap`. Any divergence is an immediate soundness failure (proof would not verify or, worse, would verify against a wrong tree).
+
+I2. **Goldilocks Montgomery encoding.** WGSL constants `BigInt = (1u, 4294967295u)` must encode the Goldilocks modulus `p = 0xFFFF_FFFF_0000_0001` and `R = 2^64`. Any drift from CPU-side `Goldilocks` semantics (e.g. canonical form vs. partially reduced form) breaks I1.
+
+I3. **Poseidon round-constant equivalence.** Constants uploaded to the GPU at init time must equal `plonky2::hash::poseidon::ALL_ROUND_CONSTANTS` byte-for-byte (in Montgomery form), and the round structure (`fullRounds → 22 partial → fullRounds`) must match the CPU permutation.
+
+I4. **Domain separation between leaf-hash and node-hash kernels** must equal the CPU semantics (which also do not separate). If we ever change CPU semantics later, we must change both kernels.
+
+I5. **Fallback determinism.** GPU/CPU runtime fallback decisions (size threshold 8192, 3.5 GiB WASM memory ceiling, missing context, GPU error) must produce the *same* digest as the GPU path. This is implied by I1 but worth a separate test.
+
+I6. **`unsafe` transmute safety.** `mem::transmute::<Vec<HashOut<F>>, Vec<H::Hash>>` in `merkle_tree.rs::from_gpu_output` is sound **only when `H::Hash == HashOut<F>`** (i.e. the `PoseidonGoldilocksConfig` family). We must add a static type-equality check (e.g. `static_assertions::assert_type_eq_all!` via an associated constant pattern, or use a trait method that bypasses transmute entirely).
+
+I7. **No unauthenticated prover-controlled GPU code.** All shaders are compile-time string literals; we must not introduce any `include_str!` from a runtime path or any `Device::create_shader_module` whose source comes from outside the binary.
+
+### 1.3 Attack vectors to enumerate (will be expanded by attacker subagent)
+
+A1. **GPU driver mis-computation.** A buggy / malicious WebGPU driver returns wrong digests. Mitigation: the verifier ultimately re-checks Merkle paths against root hashes that are absorbed into the Fiat-Shamir transcript. If GPU produces a wrong root, the proof simply will not verify. → Liveness, not soundness, concern. **Document explicitly.**
+
+A2. **Timing variance leaking witness.** Goldilocks Poseidon has data-independent control flow; the WGSL implementation also has straight-line MDS / round structure. → No new side channel introduced. To verify, attacker subagent must inspect every branch in WGSL.
+
+A3. **Read-back race.** If the staging buffer is reused while a prior `map_async` is still pending, callers could read stale data. Lita uses one staging buffer with `RefCell<Option<Buffer>>` plus per-build context lifetime — must verify mutual exclusion is guaranteed in our async runtime.
+
+A4. **Non-deterministic float / FMA.** WGSL's u32 path is integer; we must verify there are *zero* `f32` / `f16` operations in the shaders.
+
+A5. **Cross-call state leakage.** `var<private>` module-scope state in WGSL: each invocation gets its own copy, but if Lita ever uses `var<workgroup>` or `var<storage>` for ephemeral state, a compromised parallel dispatch could leak. Must enumerate every storage qualifier in the shaders.
+
+A6. **Initialization race.** `OnceCell` inside a `thread_local!` — verify the consumer cannot call `prove_async` before `initialize().await` completes.
+
+A7. **Panic on adapter request.** `request_adapter().expect(...)` becomes a JS exception; soundness-irrelevant but a denial-of-service path. Should return `Result`. Listed as a code-quality fix.
+
+A8. **Serde derive surface change.** Adding `Serialize`/`Deserialize` to `Target`, `ExtensionTarget`, `HashOutTarget`, etc. expands the on-disk representation surface. If any consumer accepts circuits from untrusted sources, a malformed `CircuitData` could trigger panics or, worse, construct invalid proofs. Must check whether any deserialized circuit data is trusted by downstream code in our repo (e.g. in `mle/` or `solidity/`).
+
+### 1.4 Out-of-scope but flagged
+
+- The Lita branch's "less-alloc" refactor in `gates/` is not security-critical but DOES touch hot paths; we will port it separately, behind its own commit, and security-review it in isolation.
+- `BuilderHook` adds a new circuit-builder extension point. It is not used by the `gpu_merkle` path, but it changes the public API surface. We will port it but tag a follow-up audit.
+
+---
+
+## 2. Pre-implementation checklist (CLAUDE.md §Cryptographic Invariant Checklist)
+
+We will not begin implementation until each is answered:
+
+- [ ] Confirm that no consumer in this repo (`mle/`, `starky/`, `projects/`) currently relies on the *non-async* `prove` entry point in a way that would be silently broken by Lita's `panic!("must be awaited on wasm with gpu_merkle")` stub. (Even though that stub is gated to `cfg(target_arch = "wasm32" + gpu_merkle)`, we must verify.)
+- [ ] Confirm that no `H::Hash` other than `HashOut<F>` is used anywhere in this repo's GPU path, and add a static type-equality check to enforce it forever.
+- [ ] Verify that `plonky2_field::Goldilocks` Montgomery semantics in this repo match what the WGSL constants assume. Specifically: `R = 2^64`, modulus `p = 0xFFFF_FFFF_0000_0001`. (Read `field/src/goldilocks_field.rs`.)
+- [ ] Verify that `plonky2::hash::poseidon::ALL_ROUND_CONSTANTS` length and ordering matches what `merkle_tree_gpu.rs` uploads.
+- [ ] Verify that this repo's `MerkleTree`, `FriProof`, `Proof`, `Target`, etc. have not diverged from Lita's `main` in a way that breaks the new derive macros. Run `cargo check` after each derive addition.
+
+---
+
+## 3. Implementation phases — REVISED to cherry-pick approach
+
+After fetching `lita/wasm` we discovered our `main` is a strict descendant of `lita/main`, so we can cherry-pick the 25 wasm commits onto our new branch. After classifying all 25 commits, the plan is reduced to 20 cherry-picks + 5 skips + 2 amendment commits.
+
+### Commits to cherry-pick (chronological order, 20 total)
+
+| # | Commit | Title | Phase tag |
+|---|--------|-------|-----------|
+| 1 | `75c5d1a5` | builder hook | C |
+| 2 | `eeb61ca9` | add as_any_mut for downcasting | C |
+| 3 | `9bd35bd0` | sort hooks key | C |
+| 4 | `0a11d11f` | serializer (1-line gate_serialization fix) | misc |
+| 5 | `b6e5e49a` | fix: use u64 in BaseSplitGenerator (#1647) — **wasm32 fix** | wasm32-fix |
+| 6 | `36910550` | fix: add missing vec | misc |
+| 7 | `7ca765a0` | **WebGPU acceleration for Merkle tree construction (#1)** | E+F+G (main) |
+| 8 | `099f6283` | use pollster::block_on | F |
+| 9 | `792e25d4` | make js-sys non optional dependency on wasm32 | D |
+| 10 | `c2cd7038` | feat: support serde to (de)serialize circuits | B |
+| 11 | `50e731fe` | feat: increase GPU Merkle CPU fallback threshold to 65536 leaves | refinement |
+| 12 | `4fa6b1cc` | chore: temp commit for debugging (kept for fidelity, retains downstream patches) | refinement |
+| 13 | `2fa2c933` | feat: optimise memory usage directly decoding leaf and node hashes | refinement |
+| 14 | `746bdf5d` | feat: fallback to cpu when memory usage is over 3.5GB | refinement |
+| 15 | `4fb3ccdb` | chore: remove log code used for debugging | refinement |
+| 16 | `a7ce5102` | refactor: simplify hash reading | refinement |
+| 17 | `80f19496` | refactor: remove unused parameters | refinement |
+| 18 | `efa5c1af` | refactor: restore debug assertion | refinement |
+| 19 | `4765208c` | refactor: improve buffer size calculation | refinement |
+| 20 | `0052d81e` | feat: lower threshold of GPU to 8192 (final tuning) | refinement |
+
+### Commits to SKIP (5)
+
+| Commit | Title | Reason |
+|--------|-------|--------|
+| `04131502` | revert generator change | touches `field/` (out of scope) and is reverted by `8a780fde` (net-zero) |
+| `8a780fde` | Revert "revert generator change" | net-zero with `04131502` |
+| `e7eefdb0` | halo2 verifier | feature creep, reverted by `1249b473` (net-zero) |
+| `1249b473` | Revert "halo2 verifier" | net-zero with `e7eefdb0` |
+| `ba617986` | massive less-alloc gates refactor | user-approved skip; only touches `gates/*` and `plonk/vanishing_poly.rs`, no overlap with in-scope commits |
+
+### Amendment commits (after all cherry-picks)
+
+| # | Title | Rationale |
+|---|-------|-----------|
+| A1 | Replace `unsafe transmute` in `from_gpu_output` with `static_assertions::assert_type_eq_all!` | Lita's version is UB if `H::Hash != HashOut<F>` (CLAUDE.md "No Silent Workarounds") |
+| A2 | Replace `request_adapter().expect(...)` with proper `Result` propagation | Code-quality fix; avoids unhandled JS exceptions |
+
+Each phase below is verified by `cargo check`. Halt on any unexpected test result (CLAUDE.md §Unexpected Test Results).
+
+### Phase A — Setup & branch hygiene
+1. Branch off `main` to `feat/wasm-webgpu-merkle`.
+2. Add Lita as a git remote: `git remote add lita https://github.com/InternetMaximalism/Lita-Plonky2.git`; fetch only the `wasm` branch.
+3. Compute `git diff lita/main..lita/wasm -- plonky2/ starky/` to get the *actual* set of changes in scope (not from our `main`, which has diverged).
+4. Cross-check with the file list in §0.
+
+### Phase B — Serde derives (low risk, prerequisite for tests)
+5. Add `Serialize`/`Deserialize` derives to: `HashOutTarget`, `MerkleCapTarget` (`hash/hash_types.rs`), `MerkleProofTarget` (`hash/merkle_proofs.rs`), `VerifierCircuitTarget` (`plonk/circuit_data.rs`), `Target`, `ExtensionTarget` (`iop/target.rs`, `iop/ext_target.rs`), `FriProof`, `Proof`, `ProofWithPublicInputs` and friends (`fri/proof.rs`, `plonk/proof.rs`).
+6. Run full test suite (CPU only). No behavior change expected.
+7. **Security gate:** confirm no consumer in this repo deserializes circuit data from an untrusted source. If it does, file a follow-up issue but do not block this phase.
+
+### Phase C — Profiling & builder_hook utilities
+8. Add `plonky2/src/util/profiling.rs` with `with_timer` / `with_timer_async`. Native uses `std::time::Instant`, wasm32 uses `js_sys::Date::now()`, no_std no-op.
+9. Add `plonky2/src/util/builder_hook.rs` with the `BuilderHook` trait and `BuilderHookRef`.
+10. Wire into `plonky2/src/util/mod.rs`.
+11. Run full test suite.
+
+### Phase D — Cargo.toml: features, deps, crate-type
+12. Add `gpu_merkle`, `gpu_merkle_verbose_time_logging`, `gpu_merkle_logging`, `merkle_debug_print`, `wasm_test_exports` features to `plonky2/Cargo.toml`.
+13. Add the target-gated wasm32 dependency block (wgpu, wasm-bindgen, wasm-bindgen-futures, web-sys, bytemuck, console_error_panic_hook, console_log, getrandom, js-sys, once_cell).
+14. Add native-side optional deps (`pollster`, `web-time`, `flume`, `gloo-timers`, `futures-channel`).
+15. Set `crate-type = ["cdylib", "rlib"]`.
+16. Add empty `gpu_merkle = []` feature to `starky/Cargo.toml`.
+17. Run `cargo check` (default features) and `cargo check --target wasm32-unknown-unknown --no-default-features` to verify nothing breaks before any GPU code lands.
+
+### Phase E — WGSL shaders (verbatim copy, then audit)
+18. Copy 5 shader files into `plonky2/shaders/` *verbatim* from Lita's `wasm` branch.
+19. **Security gate:** spawn attacker subagent to audit each shader for: integer overflow in Goldilocks mul, MDS constant correctness vs. CPU, round constant ordering, partial vs. full round count, Montgomery reduction correctness, any non-integer ops. Report appended to `tasks/todo.md`.
+20. Verify Goldilocks Montgomery constants `(1u, 4294967295u)` against `field/src/goldilocks_field.rs` modulus byte-for-byte.
+
+### Phase F — `merkle_tree_gpu.rs` host module
+21. Copy `plonky2/src/hash/merkle_tree_gpu.rs` and the module declaration in `plonky2/src/hash/mod.rs`. Keep cfg gate `cfg(all(feature = "gpu_merkle", target_arch = "wasm32"))`.
+22. **Replace the `unsafe transmute` with a safe alternative** (use `<H as Hasher<F>>::Hash::from_partial(...)` or similar; if no such API exists, add a `static_assertions::assert_type_eq_all!` and document the assumption).
+23. Replace `request_adapter().expect(...)` with a `Result`-returning path; emit a `console::error_1` and return error, don't panic.
+24. Run `cargo check --target wasm32-unknown-unknown --features gpu_merkle`.
+
+### Phase G — Async cascade in CPU-side prover entry points
+25. Modify `plonky2/src/hash/merkle_tree.rs`: split `new` into `build_cpu` + `build_gpu`, add `new_async`, `from_gpu_output` (sound version per step 22).
+26. Modify `plonky2/src/fri/oracle.rs`: add `from_values_async`, `from_coeffs_async`, `prove_openings_async`. Instrument with `with_timer_async`.
+27. Modify `plonky2/src/fri/prover.rs`: add `fri_proof_async`, `fri_committed_trees_async`. Add the `panic!` stub for the sync `fri_proof` only on `cfg(all(target_arch = "wasm32", feature = "gpu_merkle"))`.
+28. Modify `plonky2/src/plonk/prover.rs`: add `prove_async`, `prove_with_partition_witness_async`. Same cfg gating for the panic stub.
+29. Modify `plonky2/src/plonk/circuit_data.rs`: add `prove_async`.
+30. Run `cargo check` for both native and wasm32 targets, with and without `gpu_merkle`.
+
+### Phase H — Less-alloc refactor (separate commit, optional bundling)
+31. Apply the gates/* less-alloc refactors. Verify with full test suite that nothing changes behaviorally (these are pure performance edits).
+
+### Phase I — CI integration
+32. Update `.github/workflows/continuous-integration-workflow.yml` to add wasm32 build of `gpu_merkle` features (still `cargo check` only — Lita does not run wasm tests, neither will we initially).
+33. Document that no headless-browser test runs and propose this as a follow-up.
+
+### Phase J — Final security review (independent subagent)
+34. Spawn `security-review` subagent on the entire diff (NOT the same agent that implemented). Subagent receives the threat model in §1 and the CLAUDE.md cryptographic invariant checklist.
+35. Address all findings before merge.
+
+---
+
+## 4. Verification matrix
+
+| Test | Phase | Notes |
+|------|-------|-------|
+| `cargo test --workspace` (default features, native) | After every phase | Must remain green |
+| `cargo check --target wasm32-unknown-unknown --no-default-features` | D, F, G | Existing CI line |
+| `cargo check --target wasm32-unknown-unknown --features gpu_merkle` | F, G | New |
+| `cargo check --features parallel,std,timing` | D, G | Native + parallel |
+| Manual: serialize a circuit, deserialize, verify (round-trip) | B | New surface |
+| Manual: inspect WGSL constants byte-for-byte against CPU constants | E | Soundness gate |
+| Static type-equality check `H::Hash == HashOut<F>` | F | Replaces unsafe transmute |
+| Attacker subagent report applied | E, J | Crypto review |
+
+---
+
+## 5. Open questions for the user
+
+1. Should we update **only** `plonky2/` and `starky/` (Lita's surface), or do we want analogous async/GPU surfaces in `mle/` and `field/`? Recommendation: leave `mle` and `field` alone — Lita didn't touch them, and our `mle` is repo-specific.
+2. The "less-alloc" gates refactor (Phase H) is GPU-unrelated. Should we include it for parity, or skip it because it expands diff blast radius without security benefit? Recommendation: **skip** unless the user explicitly wants parity. Each less-alloc edit is an independent micro-optimization that should land in its own targeted PR with benchmarks.
+3. The `BuilderHook` API addition (Phase C) is also GPU-unrelated. Same question. Recommendation: include it because it is small, isolated, well-defined, and the `wasm` branch is its only home upstream.
+4. Branch name preference — `feat/wasm-webgpu-merkle` or something else?
+
+---
+
+## 6. Risks summary
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| WGSL constants drift from CPU semantics → invalid proofs | **Critical** | Phase E byte-for-byte comparison + attacker subagent |
+| `unsafe transmute` UB if `H::Hash != HashOut<F>` | **High** | Phase F step 22 — replace with safe alternative |
+| Async cascade not actually invoked → silent fallback to CPU on every prove call | Medium | Add a startup log assertion when `gpu_merkle` is on but `is_initialized()` is false |
+| Serde derives expand attack surface for malicious circuits | Medium | Phase B step 7 audit; follow-up issue |
+| Adding ~10 new wasm32 deps may break `--no-default-features` build | Low | Phase D step 17 verification |
+| `gpu_merkle` panics in `request_adapter` | Low | Phase F step 23 |
+| Less-alloc refactor regression in proving | Low | Skip Phase H (recommendation) |
+
+---
+
+## 7. Approval
+
+User approved (option A: faithful port; option C for security fixes after review).
+
+- [x] Skip `mle`/`field`
+- [x] Skip less-alloc refactor (already verified non-overlapping with in-scope commits)
+- [x] Include `BuilderHook` (already in our main; no extra work needed)
+- [x] Branch name `feat/wasm-webgpu-merkle`
+- [x] Replaced unsafe transmute (Amendment A1)
+- [x] User selected option C: fix all CRITICAL + HIGH findings before merge
+
+## 8. Outcome
+
+### Cherry-pick + reconciliation (Phase A–G)
+14 GPU-related Lita commits cherry-picked. Pre-existing 6 commits (BuilderHook, serializer, BaseSplitGenerator u64 fix, etc.) found already in our main. Reconciliation commit (`de311906`) threads v2-protocol params (`final_poly_coeff_len`, `max_num_query_steps`, `verifier_circuit_fri_params`, `constant_evals`) through all wasm-gpu code paths.
+
+### Amendments (Phase F step 22 + 23)
+- A1 (`24964319`): replaced Lita's UB `mem::transmute<Vec<HashOut<F>>, Vec<H::Hash>>` with a `to_bytes`/`from_bytes` round-trip.
+- A2 (`47688efa`): replaced `request_adapter().expect(...)` with `Result` propagation.
+
+### CI (Phase I)
+- `e9a22258`: added `cargo check --features gpu_merkle` step on `wasm32-unknown-unknown`.
+
+### Security review (Phase E + J — independent subagents)
+Two reviewers (one adversarial against the WGSL shaders + GPU host code, one independent against the entire diff) returned 4 CRITICAL, 2 HIGH, 5 MEDIUM, 6 LOW findings. **All findings traced to upstream Lita code, not to our cherry-pick.**
+
+CRITICAL + HIGH fixed in commit `c8b5f961`:
+- C-1 (Reviewer): `starky::prove_async` missed `observe_elements(public_inputs)` + `config.observe()` before `observe_cap(trace_cap)` — every async proof was rejected by verifier.
+- C-2 (Reviewer): `prove_with_commitment_async` skipped the entire constraint-binding stage (alphas_prime, simulating zetas, zeta_prime, compute_eval_vanishing_poly, observe_extension_elements). Mirrored sync version verbatim.
+- C1 (Attacker): WGSL leaf-hash kernel always applies Poseidon, but CPU `hash_or_noop` skips it when `len * 8 <= H::HASH_SIZE`. Added CPU fallback in `build_gpu` for short leaves.
+- C2 (Attacker / M-1): `from_gpu_output` assumed `H::HASH_SIZE == 32`. Added explicit runtime `assert_eq!`.
+- H-1 (Reviewer): `dummy_proof_async` line 131 was missing `?` on `pw.set_target`.
+- H-2 (Reviewer): `prove_with_polys` family transitively called sync FRI panic stubs on wasm-gpu. Cfg-gated the pair to non-wasm-gpu and added panic-stub variants for wasm-gpu.
+
+Severity reframing: every CRITICAL/HIGH was a **liveness** failure (proof rejected by verifier), not a **soundness** failure (false proof accepted). The verifier always uses the sync code path, so a broken async/GPU prover only causes self-inflicted DoS, not soundness compromise.
+
+### Outstanding (deferred)
+MEDIUM (M-2 to M-5) and LOW (L-1 to L-6) findings deferred to follow-up issues. Notable:
+- M-2: no automated CPU/GPU Merkle digest equivalence test.
+- M-3: unused deps `flume`, `gloo-timers` (wildcard version), duplicate `console_error_panic_hook` in `plonky2/Cargo.toml`.
+- M-5: `debug_assert_eq!` for cap-layer consistency check is elided in release builds.
+- L-1: `wasm_bindgen::memory().dyn_into().unwrap()` in `build_gpu`.
+- L-5: `parallel + gpu_merkle` on `wasm32` not viable; should be marked mutually exclusive.
+
+### Verification matrix (final)
+- [x] `cargo check -p plonky2 --features parallel` — pass.
+- [x] `cargo check -p starky` — pass.
+- [x] `cargo check --target wasm32-unknown-unknown --no-default-features` — pass.
+- [x] `cargo check --target wasm32-unknown-unknown --no-default-features --features gpu_merkle` — pass.
+
+### Branch state
+22 commits ahead of `main`; all `cargo check` targets pass; merge-ready pending the deferred MEDIUM/LOW items being either accepted as known-issues or addressed in follow-ups.


### PR DESCRIPTION
## Summary

Port the WebGPU-accelerated Merkle tree construction and the surrounding async-prover cascade from `InternetMaximalism/Lita-Plonky2@wasm` (the Lita fork's wasm branch) onto this fork's `main`. WebGPU acceleration applies to the Poseidon-Goldilocks Merkle tree only (≥ 8192 leaves); all other prover work stays on CPU. The async cascade (`*_async` variants) is required because WebGPU dispatch is fundamentally asynchronous.

The branch is **not** a multi-threaded WASM port — Lita's wasm branch never had `wasm-bindgen-rayon`, Web Workers, or atomics. The "WebGPU + multi-thread" framing was a misreading of upstream; clarified with @user before starting (see `tasks/todo.md` §0).

23 commits over `main` (vs 25 in upstream `wasm`); 5 upstream commits skipped (`ba617986` less-alloc per scope decision, two pairs of net-zero reverts).

## What's in this PR (high level)

- **20 cherry-picks** from `lita/wasm` (the 14 GPU-related commits + serde derives + small fixes; 6 commits from upstream were already in our `main`).
- **1 reconciliation commit** (`de311906`) threading our v2-protocol params (`final_poly_coeff_len`, `max_num_query_steps`, `verifier_circuit_fri_params`, `constant_evals`) through every wasm-gpu code path.
- **2 amendment commits** for safety issues already present in Lita:
  - `24964319` (A1): replaced upstream's UB `mem::transmute<Vec<HashOut<F>>, Vec<H::Hash>>` with a `to_bytes`/`from_bytes` round-trip.
  - `47688efa` (A2): replaced `request_adapter().expect(...)` with `Result` propagation.
- **1 CI commit** (`e9a22258`) adding a `cargo check --features gpu_merkle` step on `wasm32-unknown-unknown`.
- **1 critical+high security-fix commit** (`c8b5f961`) addressing every blocking finding from two independent security review subagents (one adversarial, one independent). Details below.
- **3 hygiene commits**: rustfmt, clippy `-D warnings`, no-std `block_on` shim.

## Security findings & fixes (commit `c8b5f961`)

Two review subagents (one targeting WGSL shaders + GPU host code, one targeting the entire diff) returned 4 CRITICAL + 2 HIGH findings — **all originating in upstream Lita code, not in the cherry-pick reconciliation**. Each was a *liveness* failure (proof rejected by verifier) rather than a *soundness* failure (false proof accepted): the verifier always uses the synchronous CPU path, so any divergent prover output simply fails verification.

| ID | File | Issue | Fix |
|---|---|---|---|
| C-1 | `starky/src/prover.rs::prove_async` | observed only `trace_cap` on the challenger; sync sibling and verifier observe `public_inputs` + `config` first | added the two missing observations in canonical order |
| C-2 | `starky/src/prover.rs::prove_with_commitment_async` | skipped the entire constraint-binding ritual (`alphas_prime`, simulating zetas, `zeta_prime`, `compute_eval_vanishing_poly`, `observe_extension_elements`); jumped straight to `alphas` | mirrored sync version verbatim |
| C1 (attacker) | WGSL `poseidon1_hash.wgsl` vs `Hasher::hash_or_noop` | GPU always Poseidon-permutes; CPU returns leaf bytes directly when `len * 8 ≤ HASH_SIZE` (= len ≤ 4 for PoseidonHash) | added CPU fallback in `MerkleTree::build_gpu` for short leaves |
| C2 / M-1 | `from_gpu_output` post-A1 | bytes round-trip silently assumed `H::HASH_SIZE == 32`; OOB or truncation otherwise | added explicit runtime `assert_eq!(H::HASH_SIZE, NUM_HASH_OUT_ELTS * size_of::<F>())` |
| H-1 | `dummy_proof_async` | `pw.set_target(...)` Result silently dropped (sync sibling propagates with `?`) | added `?` |
| H-2 | `prove_with_polys` family | transitively called sync `prove_openings`, which is a panic stub on wasm-gpu | cfg-gated the pair to non-wasm-gpu, added explicit panic-stub variants on wasm-gpu |

## Verification matrix (CI)

All checks below pass locally and are exercised by the existing CI workflow (with the new `gpu_merkle` step):

- [x] `cargo check -p plonky2 --features parallel` (native)
- [x] `cargo check -p starky` (native)
- [x] `cargo check --target wasm32-unknown-unknown --no-default-features` (existing CI step)
- [x] `cargo check --target wasm32-unknown-unknown --no-default-features --features gpu_merkle` (**new** CI step)
- [x] `cargo check --target wasm32-unknown-unknown --no-default-features` for starky
- [x] `cargo clippy --all-features --all-targets -- -D warnings -A incomplete-features -A clippy::uninlined_format_args` (existing CI step)
- [x] `cargo fmt --check`
- [x] `cargo test --workspace --release` (no-std excluded): all packages pass
- [x] `cargo +nightly test --no-default-features --lib --release` (no-std plonky2): **95 passed** (origin/main: 94)
- [x] `cargo +nightly test --no-default-features --lib --release` (no-std starky): 16 passed

## Out of scope / deferred to follow-ups

The two security review subagents also flagged 5 MEDIUM and 6 LOW findings. None block merge; documented in `tasks/todo.md` §8 ("Outstanding"). The notable ones:

- **M-2**: no automated CPU/GPU Merkle digest equivalence test (we have no headless-browser CI; consider `wasm-pack test` follow-up).
- **M-3**: unused deps `flume`, `gloo-timers="*"` (wildcard violates supply-chain hygiene), and a duplicate `console_error_panic_hook` in `plonky2/Cargo.toml`. These came from Lita upstream; cleaning them up is a tidy follow-up that doesn't affect this PR's scope.
- **M-5**: `from_gpu_output` cap-layer consistency check is `debug_assert_eq!`; could be promoted to `assert_eq!`.
- **L-5**: `parallel + gpu_merkle + wasm32` is not viable; could be made mutually exclusive in `Cargo.toml` with a `compile_error!`.

## Test plan

- [x] Local CI matrix (the 7 commands listed above) — all green.
- [ ] CI green on the PR.
- [ ] Manual smoke test by a downstream consumer building `gpu_merkle` against an actual browser (we have no headless-browser CI).
- [ ] Once any Lita-side bugs (e.g. `Cargo.toml` unused deps) are cleaned up in a follow-up, re-run the full review.

## Files of note for reviewers

- `plonky2/shaders/*.wgsl` — 5 new WGSL compute shaders (Goldilocks Montgomery + Poseidon + per-layer Merkle kernel). Unchanged from upstream.
- `plonky2/src/hash/merkle_tree_gpu.rs` — host-side wgpu dispatch, ~1990 LOC. Unchanged from upstream except Amendment A2.
- `plonky2/src/hash/merkle_tree.rs` — CPU/GPU split + Amendment A1 + short-leaf fallback (Attacker C1) + HASH_SIZE assertion (Attacker C2 / M-1).
- `plonky2/src/util/mod.rs` — added `nostd_block_on` so the synchronous prover wrappers compile and run on `no_std`.
- `tasks/todo.md` — full plan, threat model, and security-review outcomes (kept in-tree as a record).